### PR TITLE
fix: setup ServiceLoader for the HTTP client

### DIFF
--- a/src/main/resources/META-INF/services/io.micronaut.http.client.HttpClientFactory
+++ b/src/main/resources/META-INF/services/io.micronaut.http.client.HttpClientFactory
@@ -1,0 +1,1 @@
+io.micronaut.http.client.netty.NettyHttpClientFactory

--- a/src/main/resources/META-INF/services/io.micronaut.json.JsonMapperSupplier
+++ b/src/main/resources/META-INF/services/io.micronaut.json.JsonMapperSupplier
@@ -1,0 +1,1 @@
+io.micronaut.jackson.databind.JacksonDatabindMapperSupplier


### PR DESCRIPTION
ServiceLoader didn't work cross classloader, se we need to configure it in the plugin as Micronaut libs comes from the application classloader not the plugin one.

Fixes #98 