### PR TITLE
Fixing Typing Error in SSH Command Plugin Examples

### DIFF
--- a/src/main/java/io/kestra/plugin/fs/sftp/Delete.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Delete.java
@@ -24,7 +24,7 @@ import java.io.IOException;
         @Example(
             code = {
                 "host: localhost",
-                "port: 22",
+                "port: \"22\"",
                 "username: foo",
                 "password: pass",
                 "uri: \"/upload/dir1/file.txt\"",

--- a/src/main/java/io/kestra/plugin/fs/sftp/Download.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Download.java
@@ -24,7 +24,7 @@ import java.io.IOException;
         @Example(
             code = {
                 "host: localhost",
-                "port: 22",
+                "port: \"22\"",
                 "username: foo",
                 "password: pass",
                 "from: \"/in/file.txt\"",

--- a/src/main/java/io/kestra/plugin/fs/sftp/Downloads.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Downloads.java
@@ -25,7 +25,7 @@ import java.io.IOException;
             title = "Download a list of files and move it to an archive folders",
             code = {
                 "host: localhost",
-                "port: 22",
+                "port: \"22\"",
                 "username: foo",
                 "password: pass",
                 "from: \"/in/\"",

--- a/src/main/java/io/kestra/plugin/fs/sftp/List.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/List.java
@@ -24,7 +24,7 @@ import java.io.IOException;
         @Example(
             code = {
                 "host: localhost",
-                "port: 22",
+                "port: \"22\"",
                 "username: foo",
                 "password: pass",
                 "from: \"/upload/dir1/\"",

--- a/src/main/java/io/kestra/plugin/fs/sftp/Move.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Move.java
@@ -25,7 +25,7 @@ import java.io.IOException;
         @Example(
             code = {
                 "host: localhost",
-                "port: 22",
+                "port: \"22\"",
                 "username: foo",
                 "password: pass",
                 "from: \"/upload/dir1/file.txt\"",

--- a/src/main/java/io/kestra/plugin/fs/sftp/Upload.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Upload.java
@@ -24,7 +24,7 @@ import java.io.IOException;
         @Example(
             code = {
                 "host: localhost",
-                "port: 22",
+                "port: \"22\"",
                 "username: foo",
                 "password: pass",
                 "from: \"{{ outputs.taskid.uri }}\"",

--- a/src/main/java/io/kestra/plugin/fs/sftp/Uploads.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Uploads.java
@@ -24,7 +24,7 @@ import java.io.IOException;
                 @Example(
                         code = {
                                 "host: localhost",
-                                "port: 22",
+                                "port: \"22\"",
                                 "username: foo",
                                 "password: pass",
                                 "from:",

--- a/src/main/java/io/kestra/plugin/fs/ssh/Command.java
+++ b/src/main/java/io/kestra/plugin/fs/ssh/Command.java
@@ -49,7 +49,7 @@ import jakarta.validation.constraints.NotNull;
             title = "Run SSH command using password authentication",
             code = {
                 "host: localhost",
-                "port: 22",
+                "port: \"22\"",
                 "authMethod: PASSWORD",
                 "username: foo",
                 "password: pass",
@@ -60,7 +60,7 @@ import jakarta.validation.constraints.NotNull;
             title = "Run SSH command using public key authentication",
             code = {
                 "host: localhost",
-                "port: 22",
+                "port: \"22\"",
                 "authMethod: PUBLIC_KEY",
                 "username: root",
                 "privateKey: secret('SSH_RSA_PRIVATE_KEY')",


### PR DESCRIPTION
Hi Team,

I hope this message finds you well. I've encountered a typing error in the code examples provided for the "io.kestra.plugin.fs.ssh.Command" type, which I'd like to address with a pull request.

Upon using the plugin and referring to the documentation [here](https://develop.kestra.io/plugins/plugin-fs/tasks/ssh/io.kestra.plugin.fs.ssh.command), I noticed that the port parameter is currently defined as a string.

To rectify this, I've made adjustments to the examples within the fs plugin, ensuring that the port parameter is encapsulated within double quotation marks ("") for consistency and accuracy.

Have a great day!