### PR TITLE
fix(docs): SSH key syntax and add note about openssh

### DIFF
--- a/src/main/java/io/kestra/plugin/fs/ssh/Command.java
+++ b/src/main/java/io/kestra/plugin/fs/ssh/Command.java
@@ -57,7 +57,7 @@ import jakarta.validation.constraints.NotNull;
             }
         ),
         @Example(
-            title = "Run SSH command using public key authentication",
+            title = "Run SSH command using public key authentication (must be an OpenSSH private key)",
             code = {
                 "host: localhost",
                 "port: \"22\"",

--- a/src/main/java/io/kestra/plugin/fs/ssh/Command.java
+++ b/src/main/java/io/kestra/plugin/fs/ssh/Command.java
@@ -63,7 +63,7 @@ import jakarta.validation.constraints.NotNull;
                 "port: \"22\"",
                 "authMethod: PUBLIC_KEY",
                 "username: root",
-                "privateKey: secret('SSH_RSA_PRIVATE_KEY')",
+                "privateKey: "{{ secret('SSH_RSA_PRIVATE_KEY') }}"",
                 "commands: ['touch kestra_was_here']"
             }
         )

--- a/src/main/java/io/kestra/plugin/fs/ssh/Command.java
+++ b/src/main/java/io/kestra/plugin/fs/ssh/Command.java
@@ -63,7 +63,7 @@ import jakarta.validation.constraints.NotNull;
                 "port: \"22\"",
                 "authMethod: PUBLIC_KEY",
                 "username: root",
-                "privateKey: "{{ secret('SSH_RSA_PRIVATE_KEY') }}"",
+                "privateKey: \"{{ secret('SSH_RSA_PRIVATE_KEY') }}\"",
                 "commands: ['touch kestra_was_here']"
             }
         )


### PR DESCRIPTION
## Changes
 - Fix syntax for secret to include `{{ }}`
 - Add note about SSH key must be an OpenSSH key type