### PR TITLE
fix(docs): Fix examples looping over files' paths

### DIFF
--- a/src/main/java/io/kestra/plugin/fs/ftp/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/ftp/Trigger.java
@@ -32,11 +32,11 @@ import java.net.Proxy;
                 "tasks:",
                 "  - id: for_each_file",
                 "    type: io.kestra.plugin.core.flow.EachSequential",
-                "    value: \"{{ trigger.files | jq('.path') }}\"",
+                "    value: \"{{ trigger.files }}\"",
                 "    tasks:",
                 "      - id: return",
                 "        type: io.kestra.plugin.core.debug.Return",
-                "        format: \"{{ taskrun.value }}\"",
+                "        format: \"{{ taskrun.value | jq('.path') }}\"",
                 "",
                 "triggers:",
                 "  - id: watch",
@@ -61,18 +61,18 @@ import java.net.Proxy;
                 "tasks:",
                 "  - id: for_each_file",
                 "    type: io.kestra.plugin.core.flow.EachSequential",
-                "    value: \"{{ trigger.files | jq('.name') }}\"",
+                "    value: \"{{ trigger.files }}\"",
                 "    tasks:",
                 "      - id: return",
                 "        type: io.kestra.plugin.core.debug.Return",
-                "        format: \"{{ taskrun.value }}\"",
+                "        format: \"{{ taskrun.value | jq('.name') }}\"",
                 "      - id: delete",
                 "        type: io.kestra.plugin.fs.ftp.Delete",
                 "        host: localhost",
                 "        port: 21",
                 "        username: foo",
                 "        password: bar",
-                "        uri: \"/in/{{ taskrun.value }}\"",
+                "        uri: \"/in/{{ taskrun.value | jq('.name') }}\"",
                 "",
                 "triggers:",
                 "  - id: watch",
@@ -90,17 +90,17 @@ import java.net.Proxy;
             title = "Wait for one or more files in a given FTP server's directory and process each of these files sequentially. In this example, we restrict the trigger to only wait for CSV files in the `mydir` directory.",
             full = true,
             code = """
-                id: ftp_wait_for_csv_in_mydir
+                id: ftp_wait_for_csv_in_mydirs
                 namespace: company.team
 
                 tasks:
                   - id: each
                     type: io.kestra.plugin.core.flow.EachSequential
-                    value: "{{ trigger.files | jq('.path') }}"
+                    value: "{{ trigger.files }}"
                     tasks:
                       - id: return
                         type: io.kestra.plugin.core.debug.Return
-                        format: "{{ taskrun.value }}"
+                        format: "{{ taskrun.value | jq('.path') }}"
                     
                 triggers:
                   - id: watch

--- a/src/main/java/io/kestra/plugin/fs/ftp/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/ftp/Trigger.java
@@ -90,7 +90,7 @@ import java.net.Proxy;
             title = "Wait for one or more files in a given FTP server's directory and process each of these files sequentially. In this example, we restrict the trigger to only wait for CSV files in the `mydir` directory.",
             full = true,
             code = """
-                id: ftp_wait_for_csv_in_mydirs
+                id: ftp_wait_for_csv_in_mydir
                 namespace: company.team
 
                 tasks:

--- a/src/main/java/io/kestra/plugin/fs/ftps/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/ftps/Trigger.java
@@ -35,11 +35,11 @@ import java.net.Proxy;
                 "tasks:",
                 "  - id: for_each_file",
                 "    type: io.kestra.plugin.core.flow.EachSequential",
-                "    value: \"{{ trigger.files | jq('.path') }}\"",
+                "    value: \"{{ trigger.files }}\"",
                 "    tasks:",
                 "      - id: return",
                 "        type: io.kestra.plugin.core.debug.Return",
-                "        format: \"{{ taskrun.value }}\"",
+                "        format: \"{{ taskrun.value | jq('.path') }}\"",
                 "",
                 "triggers:",
                 "  - id: watch",
@@ -64,11 +64,11 @@ import java.net.Proxy;
                 tasks:
                   - id: each
                     type: io.kestra.plugin.core.flow.EachSequential
-                    value: "{{ trigger.files | jq('.path') }}"
+                    value: "{{ trigger.files }}"
                     tasks:
                       - id: return
                         type: io.kestra.plugin.core.debug.Return
-                        format: "{{ taskrun.value }}"
+                        format: "{{ taskrun.value | jq('.path') }}"
                     
                 triggers:
                   - id: watch

--- a/src/main/java/io/kestra/plugin/fs/sftp/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Trigger.java
@@ -31,11 +31,11 @@ import java.io.IOException;
                 "tasks:",
                 "  - id: for_each_file",
                 "    type: io.kestra.plugin.core.flow.EachSequential",
-                "    value: \"{{ trigger.files | jq('.path') }}\"",
+                "    value: \"{{ trigger.files }}\"",
                 "    tasks:",
                 "      - id: return",
                 "        type: io.kestra.plugin.core.debug.Return",
-                "        format: \"{{ taskrun.value }}\"",
+                "        format: \"{{ taskrun.value | jq('.path') }}\"",
                 "",
                 "triggers:",
                 "  - id: watch",
@@ -95,11 +95,11 @@ import java.io.IOException;
                 tasks:
                   - id: each
                     type: io.kestra.plugin.core.flow.EachSequential
-                    value: "{{ trigger.files | jq('.path') }}"
+                    value: "{{ trigger.files }}"
                     tasks:
                       - id: return
                         type: io.kestra.plugin.core.debug.Return
-                        format: "{{ taskrun.value }}"
+                        format: "{{ taskrun.value | jq('.path') }}"
                     
                 triggers:
                   - id: watch

--- a/src/main/java/io/kestra/plugin/fs/smb/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/smb/Trigger.java
@@ -33,11 +33,11 @@ import java.io.IOException;
                 "tasks:",
                 "  - id: for_each_file",
                 "    type: io.kestra.plugin.core.flow.EachSequential",
-                "    value: \"{{ trigger.files | jq('.path') }}\"",
+                "    value: \"{{ trigger.files }}\"",
                 "    tasks:",
                 "      - id: return",
                 "        type: io.kestra.plugin.core.debug.Return",
-                "        format: \"{{ taskrun.value }}\"",
+                "        format: \"{{ taskrun.value | jq('.path') }}\"",
                 "",
                 "triggers:",
                 "  - id: watch",
@@ -64,18 +64,18 @@ import java.io.IOException;
                 "tasks:",
                 "  - id: for_each_file",
                 "    type: io.kestra.plugin.core.flow.EachSequential",
-                "    value: \"{{ trigger.files | jq('.path') }}\"",
+                "    value: \"{{ trigger.files }}\"",
                 "    tasks:",
                 "      - id: return",
                 "        type: io.kestra.plugin.core.debug.Return",
-                "        format: \"{{ taskrun.value }}\"",
+                "        format: \"{{ taskrun.value | jq('.path') }}\"",
                 "      - id: delete",
                 "        type: io.kestra.plugin.fs.smb.Delete",
                 "        host: localhost",
                 "        port: 445",
                 "        username: foo",
                 "        password: bar",
-                "        uri: \"/my_share/in/{{ taskrun.value }}\"",
+                "        uri: \"/my_share/in/{{ taskrun.value | jq('.path') }}\"",
                 "",
                 "triggers:",
                 "  - id: watch",
@@ -101,11 +101,11 @@ import java.io.IOException;
                 tasks:
                   - id: each
                     type: io.kestra.plugin.core.flow.EachSequential
-                    value: "{{ trigger.files | jq('.path') }}"
+                    value: "{{ trigger.files }}"
                     tasks:
                       - id: return
                         type: io.kestra.plugin.core.debug.Return
-                        format: "{{ taskrun.value }}"
+                        format: "{{ taskrun.value | jq('.path') }}"
                     
                 triggers:
                   - id: watch


### PR DESCRIPTION
`trigger.files` is an array which is looped upon. `.path` jq should be evaluated within the loop.

Current examples fail with:
```2024-09-06 10:50:01.870
Unable to resolve state from the Flowable task: io.pebbletemplates.pebble.error.PebbleException: Unable to parse jq value ‘[{name=dump.rtf, path=kestra:///company/team/test-filechange/executions/7hwybe4Ihb0ZulMFr6ZiG3/trigger/watch/2340097534978168835.rtf, size=2645, flags=15, userId=0, groupId=0, fileType=FILE, accessDate=2024-09-02T16:40:56Z, permissions=33188, updatedDate=2024-09-06T08:48:50Z, symbolicLink=false}]’ with type ‘java.util.ArrayList’ ({{ trigger.files | jq(‘.path’) }}:1)```