### PR TITLE
feat(ssh): support OpenSSH config authentication

### DIFF
--- a/src/main/java/io/kestra/plugin/fs/ssh/SshInterface.java
+++ b/src/main/java/io/kestra/plugin/fs/ssh/SshInterface.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public interface SshInterface {
+    String ALLOW_OPEN_SSH_CONFIG = "allow-open-ssh-config";
+
     @Schema(
         title = "Hostname of the remote server"
     )
@@ -30,7 +32,6 @@ public interface SshInterface {
         title = "Username on the remote server, required for password auth method"
     )
     @PluginProperty(dynamic = true)
-    @NotNull
     String getUsername();
 
     @Schema(
@@ -51,8 +52,15 @@ public interface SshInterface {
     @PluginProperty(dynamic = true)
     String getPrivateKeyPassphrase();
 
+    @Schema(
+        title = "OpenSSH configuration directory in case the authentication method is `OPEN_SSH`."
+    )
+    @PluginProperty(dynamic = true)
+    String getOpenSSHConfigDir();
+
     enum AuthMethod {
         PASSWORD,
-        PUBLIC_KEY
+        PUBLIC_KEY,
+        OPEN_SSH
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,3 +7,8 @@ kestra:
     type: local
     local:
       base-path: /tmp/unittest
+  plugins:
+    configurations:
+      - type: io.kestra.plugin.fs.ssh.Command
+        values:
+          allow-open-ssh-config: true

--- a/src/test/resources/ssh/config
+++ b/src/test/resources/ssh/config
@@ -1,0 +1,5 @@
+Host localhost
+  HostName localhost
+  User foo
+  IdentityFile ./id_ed25519
+  IdentitiesOnly yes


### PR DESCRIPTION
Fixes https://github.com/kestra-io/kestra-ee/issues/1649

Example:
```yaml
id: ssh
namespace: company.team
tasks:
  - id: ssh
    type: io.kestra.plugin.fs.ssh.Command
    authMethod: OPEN_SSH
    host: localhost
    password: pass
    commands:
      - echo "Hello World"
```