### PR TITLE
docs: Make rootDir usage clearer

### DIFF
--- a/src/main/java/io/kestra/plugin/fs/ftp/FtpInterface.java
+++ b/src/main/java/io/kestra/plugin/fs/ftp/FtpInterface.java
@@ -25,7 +25,7 @@ public interface FtpInterface {
     Proxy.Type getProxyType();
 
     @Schema(
-        title = "Is path is relative to root dir"
+        title = "Is the path relative to the users home directory"
     )
     @PluginProperty(dynamic = false)
     Boolean getRootDir();

--- a/src/main/java/io/kestra/plugin/fs/sftp/SftpInterface.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/SftpInterface.java
@@ -50,7 +50,7 @@ public interface SftpInterface {
     String getProxyType();
 
     @Schema(
-        title = "Is path is relative to root dir"
+        title = "Is the path relative to the users home directory"
     )
     @PluginProperty(dynamic = true)
     Boolean getRootDir();


### PR DESCRIPTION
### What changes are being made and why?

The `rootDir` parameter is causing some confusion. Users believe setting this to true means that the rootDir of the host machine will be used, i.e. `/` however, the actual behavior is to use the users home directory, e.g. `/home/ftp_user` 

Updating the docs here to make it clearer that setting to `true` means that the home directory will be used

---

### How the changes have been QAed?

Received feedback from user on this change

