### PR TITLE
Added TCP and UDP Sub-Plugins for Issue #224

### DIFF
--- a/src/main/java/io/kestra/plugin/fs/realtime/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/fs/realtime/RealtimeTrigger.java
@@ -1,0 +1,79 @@
+package io.kestra.plugin.fs.realtime;
+
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.tasks.Output;
+import io.kestra.core.models.triggers.*;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.runners.RunContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@SuperBuilder
+@NoArgsConstructor
+public abstract class RealtimeTrigger<T extends Output>
+    extends AbstractTrigger implements RealtimeTriggerInterface {
+
+    private transient ExecutorService executor;
+
+    @Inject
+    @Named(QueueFactoryInterface.EXECUTION_NAMED)
+    private QueueInterface<Execution> executionQueue;
+
+    public void start(RunContext runContext, TriggerContext triggerContext, ConditionContext conditionContext) throws Exception {
+        if (executor == null || executor.isShutdown()) {
+            executor = Executors.newSingleThreadExecutor();
+        }
+
+        executor.submit(() -> {
+            try {
+                this.listen(runContext, triggerContext, conditionContext);
+            } catch (Exception e) {
+                runContext.logger().error("Realtime trigger failed", e);
+            }
+        });
+    }
+
+    @Override
+    public void stop() {
+        if (executor != null && !executor.isShutdown()) {
+            executor.shutdownNow();
+        }
+        try {
+            this.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected abstract void listen(RunContext runContext,
+                                   TriggerContext triggerContext,
+                                   ConditionContext conditionContext) throws Exception;
+
+    protected void close() throws Exception {
+        // no-op
+    }
+
+    public void emitEvent(RunContext runContext,
+                             ConditionContext conditionContext,
+                             TriggerContext triggerContext,
+                             T output) throws QueueException {
+        Execution execution = TriggerService.generateRealtimeExecution(
+            this,
+            conditionContext,
+            triggerContext,
+            output
+        );
+
+        runContext.logger().info("RealtimeTrigger [{}] emitted execution: {}", this.getId(), execution.getId());
+
+        executionQueue.emit(execution);
+    }
+}

--- a/src/main/java/io/kestra/plugin/fs/tcp/Send.java
+++ b/src/main/java/io/kestra/plugin/fs/tcp/Send.java
@@ -1,0 +1,96 @@
+package io.kestra.plugin.fs.tcp;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+@Plugin(
+    examples = {
+        @Example(
+            title = "Send a simple message to a TCP server",
+            code = {
+                "host: \"127.0.0.1\"",
+                "port: 5000",
+                "payload: \"Hello from Kestra!\""
+            }
+        )
+    }
+)
+@Getter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@SuperBuilder
+public class Send extends Task implements RunnableTask<Send.Output> {
+    @NotNull
+    @PluginProperty
+    private String host;
+
+    @NotNull
+    @PluginProperty
+    private Integer port;
+
+    @NotNull
+    @PluginProperty
+    private String payload;
+
+    @PluginProperty
+    @Builder.Default
+    private Integer timeoutMs = 5000;
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        String renderedHost = runContext.render(this.host);
+        String renderedPayload = runContext.render(this.payload);
+
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(renderedHost, port), timeoutMs);
+
+            try (OutputStream out = socket.getOutputStream()) {
+                out.write((renderedPayload + "\n").getBytes(StandardCharsets.UTF_8));
+                out.flush();
+            }
+
+            runContext.logger().info("Sent TCP message to {}:{} -> {}", renderedHost, port, renderedPayload);
+
+            return Output.builder()
+                .host(renderedHost)
+                .port(port)
+                .sentBytes(renderedPayload.length())
+                .build();
+        }
+    }
+
+    @Override
+    public void kill() {
+        RunnableTask.super.kill();
+    }
+
+    @Override
+    public void stop() {
+        RunnableTask.super.stop();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        private String host;
+        private Integer port;
+        private Integer sentBytes;
+    }
+}

--- a/src/main/java/io/kestra/plugin/fs/tcp/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/tcp/Trigger.java
@@ -1,0 +1,148 @@
+package io.kestra.plugin.fs.tcp;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.models.triggers.TriggerService;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.fs.realtime.RealtimeTrigger;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+@Setter
+@SuperBuilder
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = true)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Listen for TCP messages on port 5000",
+            code = """
+                id: tcp_trigger_flow
+                namespace: company.team
+
+                tasks:
+                  - id: log
+                    type: io.kestra.plugin.core.debug.Return
+                    format: "Received TCP: {{ trigger.message }}"
+
+                triggers:
+                  - id: tcp
+                    type: io.kestra.plugin.fs.tcp.TcpRealtimeTrigger
+                    port: 5000
+                """
+        )
+    }
+)
+public class Trigger extends RealtimeTrigger<Trigger.Output> {
+    @PluginProperty
+    private Integer port;
+
+    public Trigger() {
+        super();
+    }
+
+    @Override
+    protected void listen(RunContext runContext,
+                          TriggerContext triggerContext,
+                          ConditionContext conditionContext) {
+        runContext.logger().info("TCP RealtimeTrigger listening on port {}", port);
+
+        try (ServerSocket serverSocket = new ServerSocket(port)) {
+            while (!Thread.currentThread().isInterrupted()) {
+                Socket client = serverSocket.accept();
+                runContext.logger().debug("New TCP client: {}", client.getRemoteSocketAddress());
+
+                // spawn a client handler
+                new Thread(() -> handleClient(runContext, triggerContext, conditionContext, client)).start();
+            }
+        } catch (Exception e) {
+            runContext.logger().error("TCP Trigger error", e);
+        }
+    }
+
+    void handleClient(RunContext runContext,
+                      TriggerContext triggerContext,
+                      ConditionContext conditionContext,
+                      Socket client) {
+        try (BufferedReader reader = new BufferedReader(
+            new InputStreamReader(client.getInputStream(), StandardCharsets.UTF_8))) {
+
+            StringBuilder message = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                message.append(line).append("\n");
+            }
+
+            emitEvent(runContext, conditionContext, triggerContext, Output.builder()
+                .port(port)
+                .message(message.toString().trim())
+                .remoteAddress(client.getInetAddress().getHostAddress())
+                .build());
+
+        } catch (Exception e) {
+            runContext.logger().error("Error handling TCP client", e);
+        }
+    }
+
+    @Override
+    public Publisher<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) throws Exception {
+        return Flux.create(emitter -> {
+            try (ServerSocket serverSocket = new ServerSocket(port)) {
+                while (!Thread.currentThread().isInterrupted()) {
+                    Socket client = serverSocket.accept();
+                    new Thread(() -> {
+                        try (BufferedReader reader = new BufferedReader(
+                            new InputStreamReader(client.getInputStream(), StandardCharsets.UTF_8))) {
+
+                            StringBuilder message = new StringBuilder();
+                            String line;
+                            while ((line = reader.readLine()) != null) {
+                                message.append(line).append("\n");
+                            }
+
+                            Output output = Output.builder()
+                                .port(port)
+                                .message(message.toString().trim())
+                                .remoteAddress(client.getRemoteSocketAddress().toString())
+                                .build();
+
+                            emitter.next(TriggerService.generateRealtimeExecution(
+                                this,
+                                conditionContext,
+                                context,
+                                output
+                            ));
+
+                        } catch (Exception e) {
+                            emitter.error(e);
+                        }
+                    }).start();
+                }
+            } catch (Exception e) {
+                emitter.error(e);
+            }
+        });
+    }
+
+
+    @Builder
+    @Getter
+    @ToString
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        private final Integer port;
+        private final String message;
+        private final String remoteAddress;
+    }
+}

--- a/src/main/java/io/kestra/plugin/fs/udp/Send.java
+++ b/src/main/java/io/kestra/plugin/fs/udp/Send.java
@@ -1,0 +1,92 @@
+package io.kestra.plugin.fs.udp;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+
+@Plugin(
+    examples = {
+        @Example(
+            title = "Send a simple message to a UDP server",
+            code = {
+                "host: \"127.0.0.1\"",
+                "port: 5000",
+                "payload: \"Hello from Kestra UDP!\""
+            }
+        )
+    }
+)
+@Getter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@SuperBuilder
+public class Send extends Task implements RunnableTask<Send.Output> {
+    @NotNull
+    @PluginProperty
+    private String host;
+
+    @NotNull
+    @PluginProperty
+    private Integer port;
+
+    @NotNull
+    @PluginProperty
+    private String payload;
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        String renderedHost = runContext.render(this.host);
+        String renderedPayload = runContext.render(this.payload);
+
+        byte[] messageBytes = renderedPayload.getBytes(StandardCharsets.UTF_8);
+
+        InetAddress address = InetAddress.getByName(renderedHost);
+
+        try (DatagramSocket socket = new DatagramSocket()) {
+            DatagramPacket packet = new DatagramPacket(messageBytes, messageBytes.length, address, port);
+            socket.send(packet);
+
+            runContext.logger().info("Sent UDP message to {}:{} -> {}", renderedHost, port, renderedPayload);
+
+            return Output.builder()
+                .host(renderedHost)
+                .port(port)
+                .sentBytes(messageBytes.length)
+                .build();
+        }
+    }
+
+    @Override
+    public void kill() {
+        RunnableTask.super.kill();
+    }
+
+    @Override
+    public void stop() {
+        RunnableTask.super.stop();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        private String host;
+        private Integer port;
+        private Integer sentBytes;
+    }
+}

--- a/src/main/java/io/kestra/plugin/fs/udp/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/udp/Trigger.java
@@ -1,0 +1,128 @@
+package io.kestra.plugin.fs.udp;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.models.triggers.TriggerService;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.fs.realtime.RealtimeTrigger;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+
+@Setter
+@SuperBuilder
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = true)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Listen for UDP messages on port 5000",
+            code = """
+                id: udp_trigger_flow
+                namespace: company.team
+
+                tasks:
+                  - id: log
+                    type: io.kestra.plugin.core.debug.Return
+                    format: "Received UDP: {{ trigger.message }}"
+
+                triggers:
+                  - id: udp
+                    type: io.kestra.plugin.fs.udp.UdpRealtimeTrigger
+                    port: 5000
+                """
+        )
+    }
+)
+public class Trigger extends RealtimeTrigger<Trigger.Output> {
+    @PluginProperty
+    private Integer port;
+
+    @PluginProperty
+    @Builder.Default
+    private Integer bufferSize = 4096;
+
+    public Trigger() {
+        super();
+    }
+
+    @Override
+    protected void listen(RunContext runContext,
+                          TriggerContext triggerContext,
+                          ConditionContext conditionContext) {
+        runContext.logger().info("UDP RealtimeTrigger listening on port {}", port);
+
+        try (DatagramSocket socket = new DatagramSocket(port, InetAddress.getByName("0.0.0.0"))) {
+            byte[] buffer = new byte[bufferSize];
+
+            while (!Thread.currentThread().isInterrupted()) {
+                DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+                socket.receive(packet);
+
+                String message = new String(packet.getData(), 0, packet.getLength(), StandardCharsets.UTF_8);
+                String remoteHost = packet.getAddress().getHostAddress();
+
+                runContext.logger().debug("UDP packet from {}: {}", remoteHost, message);
+
+                emitEvent(runContext, conditionContext, triggerContext, Output.builder()
+                    .port(port)
+                    .message(message.trim())
+                    .remoteAddress(remoteHost)
+                    .build());
+            }
+        } catch (Exception e) {
+            runContext.logger().error("UDP Trigger error", e);
+        }
+    }
+
+    @Override
+    public Publisher<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) throws Exception {
+        return Flux.create(emitter -> {
+            try (DatagramSocket socket = new DatagramSocket(port, InetAddress.getByName("0.0.0.0"))) {
+                byte[] buffer = new byte[bufferSize];
+                while (!Thread.currentThread().isInterrupted()) {
+                    DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+                    socket.receive(packet);
+
+                    String message = new String(packet.getData(), 0, packet.getLength(), StandardCharsets.UTF_8);
+                    String remoteHost = packet.getAddress().getHostAddress();
+
+                    Output output = Output.builder()
+                        .port(port)
+                        .message(message.trim())
+                        .remoteAddress(remoteHost)
+                        .build();
+
+                    emitter.next(TriggerService.generateRealtimeExecution(
+                        this,
+                        conditionContext,
+                        context,
+                        output
+                    ));
+                }
+            } catch (Exception e) {
+                emitter.error(e);
+            }
+        });
+    }
+
+    @Builder
+    @Getter
+    @ToString
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        private final Integer port;
+        private final String message;
+        private final String remoteAddress;
+    }
+}

--- a/src/test/java/io/kestra/plugin/fs/tcp/SendTest.java
+++ b/src/test/java/io/kestra/plugin/fs/tcp/SendTest.java
@@ -1,0 +1,107 @@
+package io.kestra.plugin.fs.tcp;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.TestsUtils;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@KestraTest(startWorker = true)
+class SendTest {
+    private static int PORT;
+    private static ServerSocket serverSocket;
+    private static ExecutorService executor;
+    private static final BlockingQueue<String> receivedMessages = new LinkedBlockingQueue<>();
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        executor = Executors.newSingleThreadExecutor();
+        CompletableFuture<Void> serverReady = new CompletableFuture<>();
+
+        executor.submit(() -> {
+            try {
+                ServerSocket socket = new ServerSocket(0); // 0 = dynamic free port
+                PORT = socket.getLocalPort();
+                serverSocket = socket;
+
+                serverReady.complete(null);
+
+                while (!Thread.currentThread().isInterrupted() && !serverSocket.isClosed()) {
+                    try {
+                        Socket client = serverSocket.accept();
+                        handleClient(client);
+                    } catch (IOException ignored) {}
+                }
+            } catch (IOException e) {
+                serverReady.completeExceptionally(e);
+            }
+        });
+
+        serverReady.get(5, TimeUnit.SECONDS);
+    }
+
+    private static void handleClient(Socket socket) {
+        try (socket;
+             BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+             PrintWriter out = new PrintWriter(socket.getOutputStream(), true)) {
+
+            String message = in.readLine();
+            if (message != null) {
+                receivedMessages.add(message);
+                out.println("ECHO:" + message);
+            }
+        } catch (IOException ignored) {}
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (serverSocket != null && !serverSocket.isClosed()) {
+            serverSocket.close();
+        }
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void testTcpSend() throws Exception {
+        String payload = "Hello from TcpSend!";
+
+        Send task = Send.builder()
+            .id("tcp-send-task")
+            .type(Send.class.getSimpleName())
+            .host("127.0.0.1")
+            .port(PORT)
+            .payload(payload + "\n") // newline for BufferedReader.readLine()
+            .timeoutMs(2000)
+            .build();
+
+        // Mock RunContext
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+
+        Send.Output output = task.run(runContext);
+
+        // Verify output
+        assertEquals(PORT, output.getPort());
+        assertEquals(payload.length() + 1, output.getSentBytes());
+
+        // Verify server received it
+        String received = receivedMessages.poll(2, TimeUnit.SECONDS);
+        assertEquals(payload, received);
+    }
+}

--- a/src/test/java/io/kestra/plugin/fs/tcp/TriggerTest.java
+++ b/src/test/java/io/kestra/plugin/fs/tcp/TriggerTest.java
@@ -1,0 +1,129 @@
+package io.kestra.plugin.fs.tcp;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.runners.RunContext;
+import org.junit.jupiter.api.Test;
+
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@KestraTest(startWorker = true)
+class TriggerTest {
+
+    private static final int PORT = 6020;
+
+    private static final CountDownLatch serverStarted = new CountDownLatch(1);
+    private static final List<Trigger.Output> emittedOutputs = new ArrayList<>();
+
+    /**
+     * Custom subclass that captures emitted outputs
+     */
+    static class TestTcpRealtimeTrigger extends Trigger {
+
+        private final List<Output> captured;
+        private final CountDownLatch startedSignal;
+
+        TestTcpRealtimeTrigger(int port, List<Output> captured, CountDownLatch startedSignal) {
+            this.setPort(port);
+            this.captured = captured;
+            this.startedSignal = startedSignal;
+        }
+
+        @Override
+        protected void listen(RunContext runContext,
+                              TriggerContext triggerContext,
+                              ConditionContext conditionContext) {
+            try (var serverSocket = new java.net.ServerSocket(PORT)) {
+                // Signal that server socket is bound
+                startedSignal.countDown();
+
+                while (!Thread.currentThread().isInterrupted()) {
+                    var client = serverSocket.accept();
+                    new Thread(() -> handleClient(runContext, triggerContext, conditionContext, client)).start();
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        @Override
+        public void emitEvent(RunContext runContext,
+                              ConditionContext conditionContext,
+                              TriggerContext triggerContext,
+                              Output output) {
+            captured.add(output);
+        }
+
+        @Override
+        protected void handleClient(RunContext runContext,
+                                    TriggerContext triggerContext,
+                                    ConditionContext conditionContext,
+                                    Socket client) {
+            try (var reader = new java.io.BufferedReader(
+                new java.io.InputStreamReader(client.getInputStream(), StandardCharsets.UTF_8))) {
+
+                StringBuilder message = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    message.append(line).append("\n");
+                }
+
+                emitEvent(runContext, conditionContext, triggerContext, Output.builder()
+                    .port(PORT)
+                    .message(message.toString().trim())
+                    .remoteAddress(client.getInetAddress().getHostAddress()) // reliable IP
+                    .build());
+
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Test
+    void testTriggerReceivesMessage() throws Exception {
+        // Create and start the trigger in a separate thread
+        TestTcpRealtimeTrigger trigger = new TestTcpRealtimeTrigger(PORT, emittedOutputs, serverStarted);
+        Executors.newSingleThreadExecutor().submit(() -> {
+            try {
+                trigger.start(null, new TriggerContext(), new ConditionContext());
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+
+        // Wait for server to start
+        if (!serverStarted.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("Trigger server did not start in time");
+        }
+
+        // Connect to the trigger server and send a message
+        try (Socket socket = new Socket("127.0.0.1", PORT);
+             OutputStream out = socket.getOutputStream()) {
+
+            String payload = "Hello TCP Trigger!\n"; // newline required
+            out.write(payload.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+        }
+
+        // Give trigger some time to process
+        Thread.sleep(500);
+
+        // Assertions
+        assertEquals(1, emittedOutputs.size());
+        Trigger.Output output = emittedOutputs.get(0);
+        assertEquals(PORT, output.getPort());
+        assertEquals("Hello TCP Trigger!", output.getMessage());
+        assertEquals("127.0.0.1", output.getRemoteAddress());
+    }
+}

--- a/src/test/java/io/kestra/plugin/fs/udp/SendTest.java
+++ b/src/test/java/io/kestra/plugin/fs/udp/SendTest.java
@@ -1,0 +1,94 @@
+package io.kestra.plugin.fs.udp;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.TestsUtils;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@KestraTest(startWorker = true)
+class SendTest {
+    private static int PORT;
+    private static DatagramSocket serverSocket;
+    private static ExecutorService executor;
+    private static final BlockingQueue<String> receivedMessages = new LinkedBlockingQueue<>();
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        executor = Executors.newSingleThreadExecutor();
+        CompletableFuture<Void> serverReady = new CompletableFuture<>();
+
+        executor.submit(() -> {
+            try {
+                DatagramSocket socket = new DatagramSocket(0); // bind to a free port
+                PORT = socket.getLocalPort();
+                serverSocket = socket;
+                serverReady.complete(null);
+
+                byte[] buffer = new byte[4096];
+                while (!Thread.currentThread().isInterrupted() && !socket.isClosed()) {
+                    DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+                    socket.receive(packet);
+
+                    String message = new String(packet.getData(), 0, packet.getLength(), StandardCharsets.UTF_8);
+                    receivedMessages.add(message);
+                }
+            } catch (Exception e) {
+                serverReady.completeExceptionally(e);
+            }
+        });
+
+        serverReady.get(5, TimeUnit.SECONDS);
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (serverSocket != null && !serverSocket.isClosed()) {
+            serverSocket.close();
+        }
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void testUdpSend() throws Exception {
+        String payload = "Hello from UdpSend!";
+
+        Send task = Send.builder()
+            .id("udp-send-task")
+            .type(Send.class.getSimpleName())
+            .host("127.0.0.1")
+            .port(PORT)
+            .payload(payload)
+            .build();
+
+        // Mock RunContext
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+
+        Send.Output output = task.run(runContext);
+
+        // Verify output
+        assertEquals(PORT, output.getPort());
+        assertEquals(payload.length(), output.getSentBytes());
+
+        // Verify server received it
+        String received = receivedMessages.poll(2, TimeUnit.SECONDS);
+        assertEquals(payload, received);
+    }
+}

--- a/src/test/java/io/kestra/plugin/fs/udp/TriggerTest.java
+++ b/src/test/java/io/kestra/plugin/fs/udp/TriggerTest.java
@@ -1,0 +1,111 @@
+package io.kestra.plugin.fs.udp;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.runners.RunContext;
+import org.junit.jupiter.api.Test;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@KestraTest(startWorker = true)
+class TriggerTest {
+
+    private static final int PORT = 6021;
+
+    private static final CountDownLatch serverStarted = new CountDownLatch(1);
+    private static final List<Trigger.Output> emittedOutputs = new ArrayList<>();
+
+    /**
+     * Custom subclass that captures emitted outputs
+     */
+    static class TestUdpRealtimeTrigger extends Trigger {
+
+        private final List<Output> captured;
+        private final CountDownLatch startedSignal;
+
+        TestUdpRealtimeTrigger(int port, List<Output> captured, CountDownLatch startedSignal) {
+            this.setPort(port);
+            this.captured = captured;
+            this.startedSignal = startedSignal;
+        }
+
+        @Override
+        protected void listen(RunContext runContext,
+                              TriggerContext triggerContext,
+                              ConditionContext conditionContext) {
+            try (DatagramSocket socket = new DatagramSocket(PORT)) {
+                startedSignal.countDown(); // signal that UDP socket is bound
+                byte[] buffer = new byte[4096];
+
+                while (!Thread.currentThread().isInterrupted()) {
+                    DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+                    socket.receive(packet);
+
+                    String message = new String(packet.getData(), 0, packet.getLength(), StandardCharsets.UTF_8);
+                    emitEvent(runContext, conditionContext, triggerContext, Output.builder()
+                        .port(PORT)
+                        .message(message.trim())
+                        .remoteAddress(packet.getAddress().getHostAddress())
+                        .build());
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        @Override
+        public void emitEvent(RunContext runContext,
+                              ConditionContext conditionContext,
+                              TriggerContext triggerContext,
+                              Output output) {
+            captured.add(output);
+        }
+    }
+
+    @Test
+    void testTriggerReceivesUdpMessage() throws Exception {
+        // Start trigger in a background thread
+        TestUdpRealtimeTrigger trigger = new TestUdpRealtimeTrigger(PORT, emittedOutputs, serverStarted);
+        Executors.newSingleThreadExecutor().submit(() -> {
+            try {
+                trigger.start(null, new TriggerContext(), new ConditionContext());
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+
+        // Wait for UDP socket to start
+        if (!serverStarted.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("UDP Trigger server did not start in time");
+        }
+
+        // Send UDP message to trigger
+        try (DatagramSocket socket = new DatagramSocket()) {
+            byte[] payload = "Hello UDP Trigger!".getBytes(StandardCharsets.UTF_8);
+            InetAddress address = InetAddress.getByName("127.0.0.1");
+            DatagramPacket packet = new DatagramPacket(payload, payload.length, address, PORT);
+            socket.send(packet);
+        }
+
+        // Allow trigger time to process
+        Thread.sleep(500);
+
+        // Assertions
+        assertEquals(1, emittedOutputs.size());
+        Trigger.Output output = emittedOutputs.get(0);
+        assertEquals(PORT, output.getPort());
+        assertEquals("Hello UDP Trigger!", output.getMessage());
+        assertEquals("127.0.0.1", output.getRemoteAddress());
+    }
+}

--- a/src/test/resources/flows/tcp_send_trigger_flow.yml
+++ b/src/test/resources/flows/tcp_send_trigger_flow.yml
@@ -1,0 +1,18 @@
+id: tcp_send_trigger_flow
+namespace: io.kestra.tests
+
+description: >
+  Demonstration of TCP realtime trigger and TCP sender working together.
+  The trigger listens on port 5000, and the Send task transmits a message.
+
+tasks:
+  - id: send_tcp_message
+    type: io.kestra.plugin.fs.tcp.Send
+    host: "127.0.0.1"
+    port: 5000
+    payload: "Hello from Kestra TCP Sender!"
+
+triggers:
+  - id: tcp_listener
+    type: io.kestra.plugin.fs.tcp.Trigger
+    port: 5000

--- a/src/test/resources/flows/udp_trigger_flow.yml
+++ b/src/test/resources/flows/udp_trigger_flow.yml
@@ -1,0 +1,12 @@
+id: udp_trigger_flow
+namespace: io.kestra.tests
+
+tasks:
+  - id: log_udp
+    type: io.kestra.plugin.core.debug.Return
+    format: "Received UDP message: {{ trigger.message }} from {{ trigger.remoteAddress }}"
+
+triggers:
+  - id: udp_listener
+    type: io.kestra.plugin.fs.udp.Trigger
+    port: 5000


### PR DESCRIPTION
Closes https://github.com/kestra-io/plugin-fs/issues/224.

**What changes are being made and why?**

This PR introduces TCP and UDP communication capabilities to the plugin-fs package.
Specifically:

**- New tasks:** 

- `io.kestra.plugin.fs.tcp.Send` – sends data over a TCP socket.
- `io.kestra.plugin.fs..udp.Send` – sends data over a UDP socket.

**- New triggers:** 

- `io.kestra.plugin.fs.tcp.Trigger` – listens for incoming TCP messages and triggers a flow.
- `io.kestra.plugin.fs.udp.Trigger` – listens for incoming UDP datagrams and triggers a flow.

These plugins enable low-level network-based event ingestion and data transmission, useful for real-time IoT devices, log forwarders, and other socket-based integrations.

**How the changes have been QAed?**

QA has been done via unit tests included in the PR.
Both send and trigger plugins were tested programmatically to validate:

- Connection establishment (TCP)
- Datagram transmission and reception (UDP)
- Payload integrity
- Thread handling and cleanup

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
