### PR TITLE
refactor: Created a local Output class containing only releavant fields and not using ScriptOutput

### DIFF
--- a/src/test/java/io/kestra/plugin/fs/ssh/CommandTest.java
+++ b/src/test/java/io/kestra/plugin/fs/ssh/CommandTest.java
@@ -6,7 +6,6 @@ import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.fs.ssh.SshInterface.AuthMethod;
-import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -48,7 +47,7 @@ class CommandTest {
             })
             .build();
 
-        ScriptOutput run = command.run(TestsUtils.mockRunContext(runContextFactory, command, Map.of()));
+        Command.Output run = command.run(TestsUtils.mockRunContext(runContextFactory, command, Map.of()));
 
         Thread.sleep(500);
 
@@ -86,7 +85,7 @@ class CommandTest {
             })
             .build();
 
-        ScriptOutput run = command.run(TestsUtils.mockRunContext(runContextFactory, command, Map.of()));
+        Command.Output run = command.run(TestsUtils.mockRunContext(runContextFactory, command, Map.of()));
 
         Thread.sleep(500);
 
@@ -116,7 +115,7 @@ class CommandTest {
             })
             .build();
 
-        ScriptOutput run = command.run(TestsUtils.mockRunContext(runContextFactory, command, Map.of()));
+        Command.Output run = command.run(TestsUtils.mockRunContext(runContextFactory, command, Map.of()));
 
         Thread.sleep(500);
 


### PR DESCRIPTION
Closes #230 

### What changes are being made and why?
Create a local Output class implementing the core Output interface containing only relevant fields to the ssh command output and not generic ScriptOutput fields like outputFiles, taskRunner etc .

### How the changes have been QAed?
Loaded the plugin and saw the documentation changes while adding an SSH flow. Attaching screenshot below showing only the relevant documentation details
<img width="958" height="287" alt="Screenshot from 2025-10-21 21-28-24" src="https://github.com/user-attachments/assets/677c1a51-82aa-482e-9ac7-8e1b005393a9" />
<img width="965" height="647" alt="Screenshot from 2025-10-21 21-28-43" src="https://github.com/user-attachments/assets/8064376d-3f0f-417f-8ac3-17075407725c" />


---

### Setup Instructions
Add the plugin-fs to kestra before running it

---

### Contributor Checklist ✅

- [X] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [X] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [X] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [X] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`).
- [X] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
