### PR TITLE
refactor: replace @slf4j with runContext.logger()

### DIFF
--- a/src/test/java/io/kestra/plugin/fs/local/LocalUtils.java
+++ b/src/test/java/io/kestra/plugin/fs/local/LocalUtils.java
@@ -9,7 +9,6 @@ import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.fs.AbstractUtils;
 import io.micronaut.context.annotation.Prototype;
 import jakarta.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -18,7 +17,6 @@ import java.util.Map;
 import java.util.Objects;
 
 
-@Slf4j
 @Prototype
 public class LocalUtils {
 


### PR DESCRIPTION
This PR removes `@Slf4j` annotations and uses execution-specific `runContext.logger()` where applicable. This aligns the plugin with project-wide logging conventions.

### What changes are being made and why?

- Removed unused `@Slf4j` annotations
- **Preserved `@Slf4j` in `BasicUserInfo` callback** - where `RunContext` is not available


Related to kestra-io/kestra#12770

***

### How the changes have been QAed?

✅ Code compiles with no errors or warnings
✅ No functional changes - refactoring only