### PR TITLE
feat!: BREAKING CHANGE - add a maxFiles property to limit files

### DIFF
--- a/src/main/java/io/kestra/plugin/fs/ftp/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/ftp/Trigger.java
@@ -72,7 +72,7 @@ import java.net.Proxy;
                         host: localhost
                         port: 21
                         username: foo
-                        password: bar
+                        password: "{{ secret('FTP_PASSWORD') }}"
                         uri: "/in/{{ taskrun.value | jq('.name') }}"
 
                 triggers:
@@ -81,7 +81,7 @@ import java.net.Proxy;
                     host: localhost
                     port: 21
                     username: foo
-                    password: bar
+                    password: "{{ secret('FTP_PASSWORD') }}"
                     from: "/in/"
                     interval: PT10S
                     action: NONE
@@ -109,12 +109,12 @@ import java.net.Proxy;
                     host: localhost
                     port: "21"
                     username: foo
-                    password: bar
+                    password: "{{ secret('FTP_PASSWORD') }}"
                     from: "mydir/"
                     regExp: ".*.csv"
                     action: MOVE
                     moveDirectory: "archive/"
-                    interval: PTS
+                    interval: PT10S
                 """
         )
     }

--- a/src/main/java/io/kestra/plugin/fs/ftps/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/ftps/Trigger.java
@@ -82,7 +82,7 @@ import java.net.Proxy;
                     regExp: ".*.csv"
                     action: MOVE
                     moveDirectory: "archive/"
-                    interval: PTS
+                    interval: PT10S
                 """
         )
     }

--- a/src/main/java/io/kestra/plugin/fs/nfs/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/nfs/Trigger.java
@@ -92,6 +92,12 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
     @Schema(title = "Time-to-live for the trigger state.")
     private Property<Duration> stateTtl;
 
+    @Builder.Default
+    @Schema(
+        title = "The maximum number of files to retrieve at once"
+    )
+    private Property<Integer> maxFiles = Property.ofValue(25);
+
     @Override
     public Duration getInterval() {
         return this.interval;
@@ -154,6 +160,11 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
 
         if (toFire.isEmpty()) {
             logger.debug("No new or updated files found.");
+            return Optional.empty();
+        }
+
+        if (toFire.size() > runContext.render(this.maxFiles).as(Integer.class).orElse(25)) {
+            logger.warn("Too many files to process, skipping");
             return Optional.empty();
         }
 

--- a/src/main/java/io/kestra/plugin/fs/sftp/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Trigger.java
@@ -28,7 +28,7 @@ import java.io.IOException;
             code = """
                 id: sftp_trigger_flow
                 namespace: company.team
-                
+
                 tasks:
                   - id: for_each_file
                     type: io.kestra.plugin.core.flow.ForEach
@@ -37,7 +37,7 @@ import java.io.IOException;
                       - id: return
                         type: io.kestra.plugin.core.debug.Return
                         format: "{{ taskrun.value | jq('.path') }}"
-                
+
                 triggers:
                   - id: watch
                     type: io.kestra.plugin.fs.sftp.Trigger
@@ -57,7 +57,7 @@ import java.io.IOException;
             code = """
                 id: sftp_trigger_flow
                 namespace: company.team
-                
+
                 tasks:
                   - id: for_each_file
                     type: io.kestra.plugin.core.flow.ForEach
@@ -71,16 +71,16 @@ import java.io.IOException;
                         host: localhost
                         port: 6622
                         username: foo
-                        password: bar
+                        password: "{{ secret('SFTP_PASSWORD') }}"
                         uri: "/in/{{ taskrun.value }}"
-                
+
                 triggers:
                   - id: watch
                     type: io.kestra.plugin.fs.sftp.Trigger
                     host: localhost
                     port: 6622
                     username: foo
-                    password: bar
+                    password: "{{ secret('SFTP_PASSWORD') }}"
                     from: "/in/"
                     interval: PT10S
                     action: NONE
@@ -101,21 +101,21 @@ import java.io.IOException;
                       - id: return
                         type: io.kestra.plugin.core.debug.Return
                         format: "{{ taskrun.value | jq('.path') }}"
-                
+
                 triggers:
                   - id: watch
                     type: io.kestra.plugin.fs.sftp.Trigger
                     host: localhost
                     port: "6622"
                     username: foo
-                    password: bar
+                    password: "{{ secret('SFTP_PASSWORD') }}"
                     from: "mydir/"
                     regExp: ".*.csv"
                     action: MOVE
                     moveDirectory: "archive/"
-                    interval: PTS
+                    interval: PT10S
                 """
-        )          
+        )
     }
 )
 public class Trigger extends io.kestra.plugin.fs.vfs.Trigger implements SftpInterface {

--- a/src/main/java/io/kestra/plugin/fs/smb/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/smb/Trigger.java
@@ -30,7 +30,7 @@ import java.io.IOException;
             code = """
                 id: smb_trigger_flow
                 namespace: company.team
-                
+
                 tasks:
                   - id: for_each_file
                     type: io.kestra.plugin.core.flow.ForEach
@@ -39,14 +39,14 @@ import java.io.IOException;
                       - id: return
                         type: io.kestra.plugin.core.debug.Return
                         format: "{{ taskrun.value | jq('.path') }}"
-                
+
                 triggers:
                   - id: watch
                     type: io.kestra.plugin.fs.smb.Trigger
                     host: localhost
                     port: "445"
                     username: foo
-                    password: bar
+                    password: "{{ secret('SMB_PASSWORD') }}"
                     from: "/my_share/in/"
                     interval: PT10S
                     action: MOVE
@@ -61,7 +61,7 @@ import java.io.IOException;
             code = """
                 id: smb_trigger_flow
                 namespace: company.team
-                
+
                 tasks:
                   - id: for_each_file
                     type: io.kestra.plugin.core.flow.ForEach
@@ -77,7 +77,7 @@ import java.io.IOException;
                         username: foo
                         password: "{{ secret('SMB_PASSWORD') }}"
                         uri: "/my_share/in/{{ taskrun.value | jq('.path') }}"
-                
+
                 triggers:
                   - id: watch
                     type: io.kestra.plugin.fs.smb.Trigger
@@ -107,7 +107,7 @@ import java.io.IOException;
                       - id: return
                         type: io.kestra.plugin.core.debug.Return
                         format: "{{ taskrun.value | jq('.path') }}"
-                
+
                 triggers:
                   - id: watch
                     type: io.kestra.plugin.fs.smb.Trigger
@@ -119,7 +119,7 @@ import java.io.IOException;
                     regExp: ".*.csv"
                     action: MOVE
                     moveDirectory: "my_share/archivedir"
-                    interval: PTS
+                    interval: PT10S
                 """
         )
     }

--- a/src/main/java/io/kestra/plugin/fs/vfs/Downloads.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/Downloads.java
@@ -52,6 +52,12 @@ public abstract class Downloads extends AbstractVfsTask implements RunnableTask<
     @Builder.Default
     private Property<Boolean> recursive = Property.ofValue(false);
 
+    @Builder.Default
+    @Schema(
+        title = "The maximum number of files to retrieve at once"
+    )
+    private Property<Integer> maxFiles = Property.ofValue(25);
+
     public Output run(RunContext runContext) throws Exception {
         Logger logger = runContext.logger();
 
@@ -79,6 +85,15 @@ public abstract class Downloads extends AbstractVfsTask implements RunnableTask<
                 .stream()
                 .filter(file -> file.getFileType() == FileType.FILE)
                 .toList();
+
+            int rMaxFiles = runContext.render(this.maxFiles).as(Integer.class).orElse(25);
+            if (files.size() > rMaxFiles) {
+                logger.warn("Too many files to process, skipping");
+                return Output.builder()
+                    .files(java.util.List.of())
+                    .outputFiles(Map.of())
+                    .build();
+            }
 
             java.util.List<io.kestra.plugin.fs.vfs.models.File> list = files
                 .stream()

--- a/src/main/java/io/kestra/plugin/fs/vfs/Uploads.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/Uploads.java
@@ -45,12 +45,26 @@ public abstract class Uploads extends AbstractVfsTask implements RunnableTask<Up
     @NotNull
     private Property<String> to;
 
+    @Builder.Default
+    @Schema(
+        title = "The maximum number of files to retrieve at once"
+    )
+    private Property<Integer> maxFiles = Property.ofValue(25);
+
     public Output run(RunContext runContext) throws Exception {
         try (StandardFileSystemManager fsm = new KestraStandardFileSystemManager(runContext)) {
             fsm.setConfiguration(StandardFileSystemManager.class.getResource(KestraStandardFileSystemManager.CONFIG_RESOURCE));
             fsm.init();
 
             String[] renderedFrom = parseFromProperty(runContext);
+
+            int rMaxFiles = runContext.render(this.maxFiles).as(Integer.class).orElse(25);
+            if (renderedFrom.length > rMaxFiles) {
+                runContext.logger().warn("Too many files to process, skipping");
+                return Output.builder()
+                    .files(List.of())
+                    .build();
+            }
 
             List<Upload.Output> outputs = Arrays.stream(renderedFrom).map(throwFunction(fromURI -> {
                 var rTo = runContext.render(this.to).as(String.class).orElseThrow();

--- a/src/test/java/io/kestra/plugin/fs/AbstractFileTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/fs/AbstractFileTriggerTest.java
@@ -7,18 +7,16 @@ import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.LocalFlowRepositoryLoader;
 import io.kestra.core.runners.RunContextFactory;
-import io.kestra.core.runners.Worker;
-import io.kestra.scheduler.AbstractScheduler;
 import io.kestra.core.services.FlowListenersInterface;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.jdbc.runner.JdbcScheduler;
 import io.kestra.plugin.fs.vfs.models.File;
+import io.kestra.scheduler.AbstractScheduler;
 import io.kestra.worker.DefaultWorker;
 import io.micronaut.context.ApplicationContext;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
@@ -72,16 +70,17 @@ public abstract class AbstractFileTriggerTest {
 
             // wait for execution
             Flux<Execution> receive = TestsUtils.receive(executionQueue, execution -> {
-                if (execution.getLeft().getFlowId().equals(triggeringFlowId())){
+                if (execution.getLeft().getFlowId().equals(triggeringFlowId())) {
                     last.set(execution.getLeft());
 
                     queueCount.countDown();
                 }
             });
 
-
             String out1 = FriendlyId.createFriendlyId();
             String toUploadDir = "/upload/trigger";
+            cleanupRemoteDir(toUploadDir);
+            cleanupRemoteDir(toUploadDir + "-move");
             utils().upload(toUploadDir + "/" + out1);
             String out2 = FriendlyId.createFriendlyId();
             utils().upload(toUploadDir + "/" + out2);
@@ -114,25 +113,25 @@ public abstract class AbstractFileTriggerTest {
         // scheduler
         try (
             AbstractScheduler scheduler = new JdbcScheduler(
-            this.applicationContext,
-            this.flowListenersService
-        );
+                this.applicationContext,
+                this.flowListenersService
+            );
             DefaultWorker worker = applicationContext.createBean(DefaultWorker.class, IdUtils.create(), 8, null)
         ) {
             AtomicReference<Execution> last = new AtomicReference<>();
 
             // wait for execution
             Flux<Execution> receive = TestsUtils.receive(executionQueue, execution -> {
-                if (execution.getLeft().getFlowId().equals(triggeringFlowId() + "-none-action")){
+                if (execution.getLeft().getFlowId().equals(triggeringFlowId() + "-none-action")) {
                     last.set(execution.getLeft());
 
                     queueCount.countDown();
                 }
             });
 
-
             String out1 = FriendlyId.createFriendlyId();
             String toUploadDir = "/upload/trigger-none";
+            cleanupRemoteDir(toUploadDir);
             utils().upload(toUploadDir + "/" + out1);
             String out2 = FriendlyId.createFriendlyId();
             utils().upload(toUploadDir + "/" + out2);
@@ -172,7 +171,7 @@ public abstract class AbstractFileTriggerTest {
         ) {
             // wait for execution
             Flux<Execution> receive = TestsUtils.receive(executionQueue, execution -> {
-                if (execution.getLeft().getFlowId().equals(triggeringFlowId() + "-missing")){
+                if (execution.getLeft().getFlowId().equals(triggeringFlowId() + "-missing")) {
                     last.set(execution.getLeft());
 
                     queueCount.countDown();
@@ -180,6 +179,7 @@ public abstract class AbstractFileTriggerTest {
             });
 
             String file = FriendlyId.createFriendlyId();
+            cleanupRemoteDir("/upload/trigger-missing");
             utils().upload("/upload/trigger-missing/" + file);
 
             worker.run();
@@ -196,6 +196,19 @@ public abstract class AbstractFileTriggerTest {
             assertThat(trigger.size(), is(1));
 
             utils().delete("/upload/trigger-missing/" + file);
+        }
+    }
+
+    private void cleanupRemoteDir(String dir) {
+        try {
+            var list = utils().list(dir);
+            for (File file : list.getFiles()) {
+                String deletePath = file.getServerPath() != null ?
+                    file.getServerPath().getPath() :
+                    file.getPath().toString();
+                utils().delete(deletePath);
+            }
+        } catch (Exception ignored) {
         }
     }
 }

--- a/src/test/java/io/kestra/plugin/fs/ftp/DownloadsTest.java
+++ b/src/test/java/io/kestra/plugin/fs/ftp/DownloadsTest.java
@@ -83,4 +83,31 @@ class DownloadsTest {
 
         assertThat(ftpUtils.list(toUploadDir).getFiles().size(), is(2));
     }
+
+    @Test
+    void run_MaxFilesShouldSkip() throws Exception {
+        String toUploadDir = "/upload/" + random + "-maxfiles";
+        String out1 = FriendlyId.createFriendlyId();
+        ftpUtils.upload(toUploadDir + "/" + out1 + ".txt");
+        String out2 = FriendlyId.createFriendlyId();
+        ftpUtils.upload(toUploadDir + "/" + out2 + ".txt");
+
+        Downloads task = Downloads.builder()
+            .id(DownloadsTest.class.getSimpleName())
+            .type(DownloadsTest.class.getName())
+            .from(Property.ofValue(toUploadDir + "/"))
+            .action(Property.ofValue(Downloads.Action.NONE))
+            .maxFiles(Property.ofValue(1))
+            .host(Property.ofValue("localhost"))
+            .port(Property.ofValue("6621"))
+            .username(USERNAME)
+            .password(PASSWORD)
+            .build();
+
+        Downloads.Output run = task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()));
+
+        assertThat(run.getFiles().size(), is(0));
+        assertThat(run.getOutputFiles().size(), is(0));
+        assertThat(ftpUtils.list(toUploadDir).getFiles().size(), is(2));
+    }
 }

--- a/src/test/java/io/kestra/plugin/fs/ftp/ListTest.java
+++ b/src/test/java/io/kestra/plugin/fs/ftp/ListTest.java
@@ -137,4 +137,26 @@ class ListTest {
         assertThat(run.getFiles().size(), is(1));
         assertThat(run.getFiles().getFirst().getName(), is(filename));
     }
+
+    @Test
+    void maxFilesShouldSkip() throws Exception {
+        String dir = "/" + IdUtils.create();
+        ftpUtils.upload("upload" + dir + "/file1.yaml");
+        ftpUtils.upload("upload" + dir + "/file2.yaml");
+
+        List task = List.builder()
+            .id(ListTest.class.getSimpleName())
+            .type(ListTest.class.getName())
+            .from(Property.ofValue("/upload" + dir))
+            .maxFiles(Property.ofValue(1))
+            .host(Property.ofValue("localhost"))
+            .port(Property.ofValue("6621"))
+            .username(USERNAME)
+            .password(PASSWORD)
+            .build();
+
+        List.Output run = task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()));
+
+        assertThat(run.getFiles().size(), is(0));
+    }
 }

--- a/src/test/java/io/kestra/plugin/fs/ftp/UploadsTest.java
+++ b/src/test/java/io/kestra/plugin/fs/ftp/UploadsTest.java
@@ -84,4 +84,25 @@ class UploadsTest {
                 Matchers.is(Matchers.in(remoteFileUris))
         ));
     }
+
+    @Test
+    void run_maxFilesShouldSkip() throws Exception {
+        URI uri1 = ftpUtils.uploadToStorage();
+        URI uri2 = ftpUtils.uploadToStorage();
+
+        Uploads uploadsTask = Uploads.builder().id(UploadsTest.class.getSimpleName())
+            .type(UploadsTest.class.getName())
+            .from(List.of(uri1.toString(), uri2.toString()))
+            .to(Property.ofValue("/upload/" + random + "/max-files/"))
+            .maxFiles(Property.ofValue(1))
+            .host(Property.ofValue("localhost"))
+            .port(Property.ofValue("6621"))
+            .username(USERNAME)
+            .password(PASSWORD)
+            .build();
+
+        Uploads.Output uploadsRun = uploadsTask.run(TestsUtils.mockRunContext(runContextFactory, uploadsTask, Map.of()));
+
+        assertThat(uploadsRun.getFiles().size(), is(0));
+    }
 }

--- a/src/test/java/io/kestra/plugin/fs/local/ListTest.java
+++ b/src/test/java/io/kestra/plugin/fs/local/ListTest.java
@@ -60,4 +60,21 @@ class ListTest {
 
         assertThat(output.getCount(), is(3));
     }
+
+    @Test
+    void listFilesWithMaxFiles() throws Exception {
+        List task = List.builder()
+            .id(ListTest.class.getSimpleName())
+            .type(List.class.getName())
+            .from(Property.ofValue(tempDir.toString()))
+            .regExp(Property.ofValue(".*\\.csv"))
+            .recursive(Property.ofValue(true))
+            .maxFiles(Property.ofValue(2))
+            .build();
+
+        List.Output output = task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()));
+
+        assertThat(output.getFiles(), is(empty()));
+        assertThat(output.getCount(), is(0));
+    }
 }

--- a/src/test/java/io/kestra/plugin/fs/local/TriggerTest.java
+++ b/src/test/java/io/kestra/plugin/fs/local/TriggerTest.java
@@ -149,6 +149,31 @@ class TriggerTest extends AbstractTriggerTest {
     }
 
     @Test
+    void maxFilesShouldSkipExecution() throws Exception {
+        Path sourceDir = Paths.get("/tmp/trigger-maxfiles");
+        Files.createDirectories(sourceDir);
+
+        try {
+            Files.writeString(sourceDir.resolve("file1.txt"), "file1");
+            Files.writeString(sourceDir.resolve("file2.txt"), "file2");
+
+            io.kestra.plugin.fs.local.Trigger trigger = io.kestra.plugin.fs.local.Trigger.builder()
+                .id(TriggerTest.class.getSimpleName())
+                .type(io.kestra.plugin.fs.local.Trigger.class.getName())
+                .from(Property.ofValue(sourceDir.toString()))
+                .maxFiles(Property.ofValue(1))
+                .build();
+
+            var context = TestsUtils.mockTrigger(runContextFactory, trigger);
+            Optional<Execution> execution = trigger.evaluate(context.getKey(), context.getValue());
+
+            assertThat(execution.isEmpty(), is(true));
+        } finally {
+            cleanup(sourceDir);
+        }
+    }
+
+    @Test
     void moveWithRegexAndRecursiveShouldPreserveDirectoryStructure() throws Exception {
         Path sourceDir = Paths.get("/tmp/test-recursive");
         Path subDir1 = sourceDir.resolve("subdir1");

--- a/src/test/java/io/kestra/plugin/fs/nfs/ListTest.java
+++ b/src/test/java/io/kestra/plugin/fs/nfs/ListTest.java
@@ -80,7 +80,7 @@ class ListTest {
             files = stream
                 .filter(path -> !path.equals(nfsMountPoint))
                 .map(throwFunction(recursiveTask::mapToFile))
-                .collect(Collectors.toList());
+                .toList();
         }
         assertThat(files, hasSize(4));
 
@@ -96,7 +96,25 @@ class ListTest {
         assertThat(run.getFiles(), hasSize(2));
         List<String> foundNames = run.getFiles().stream()
             .map(io.kestra.plugin.fs.nfs.List.File::getName)
-            .collect(Collectors.toList());
+            .toList();
         assertThat(foundNames, Matchers.containsInAnyOrder("file1.txt", "file3.txt"));
+    }
+
+    @Test
+    void list_files_with_max_files() throws Exception {
+        Files.createFile(nfsMountPoint.resolve("file1.txt"));
+        Files.createFile(nfsMountPoint.resolve("file2.txt"));
+
+        io.kestra.plugin.fs.nfs.List task = io.kestra.plugin.fs.nfs.List.builder()
+            .id("list-max-files")
+            .type(io.kestra.plugin.fs.nfs.List.class.getName())
+            .from(Property.ofValue(nfsMountPoint.toString()))
+            .maxFiles(Property.ofValue(1))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        io.kestra.plugin.fs.nfs.List.Output run = task.run(runContext);
+
+        assertThat(run.getFiles(), is(List.of()));
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -24,6 +24,10 @@ kestra:
         values:
           allowed-paths:
             - /tmp
+      - type: io.kestra.plugin.fs.local.Downloads
+        values:
+          allowed-paths:
+            - /tmp
       - type: io.kestra.plugin.fs.local.Upload
         values:
           allowed-paths:


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra/issues/14275 

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

Create 30 files in a local file system folder:

```bash
➜  path touch toto{1..30}.txt
➜  path ll
total 0
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto10.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto11.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto12.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto13.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto14.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto15.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto16.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto17.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto18.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto19.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto1.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto20.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto21.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto22.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto23.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto24.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto25.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto26.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto27.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto28.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto29.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto2.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto30.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto3.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto4.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto5.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto6.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto7.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto8.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto9.txt
➜  path pwd
/home/francois/dev/allowed/path
```

Make this path an allowed one in the Kestra EE configuration:

```yaml
kestra:
  plugins:
    configurations:
      - type: io.kestra.plugin.fs.local.List
        values:
          allowed-paths:
            - /home/francois/dev/allowed/path
```

Flow to list the files from this local FS folder:

```yaml
id: fs_local_list
namespace: company.team

tasks:
  - id: list_files
    type: io.kestra.plugin.fs.local.List
    from: "/home/francois/dev/allowed/path"
    regExp: ".*.txt"
    recursive: true
```

Results, we're blocked as expected since the default maxFiles value is 25:

<img width="3018" height="603" alt="image" src="https://github.com/user-attachments/assets/3b06981e-d259-4db1-b7cd-6c811ebbf740" />

Remove 10 files to be under the threshold:

```bash
➜  path rm toto{20..30}.txt
➜  path ll                       
total 0
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto10.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto11.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto12.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto13.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto14.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto15.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto16.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto17.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto18.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto19.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto1.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto2.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto3.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto4.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto5.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto6.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto7.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto8.txt
-rw-rw-r-- 1 francois francois 0 janv. 23 14:40 toto9.txt
➜  path pwd      
/home/francois/dev/allowed/path
```

Retry the same flow than above (no warning anymore):

<img width="3006" height="528" alt="image" src="https://github.com/user-attachments/assets/d1ca1df3-a8a1-4aed-9615-88a0f20c638e" />

And got the 20 remaining files as outputs:

<img width="1725" height="1342" alt="image" src="https://github.com/user-attachments/assets/f29a3379-0f21-4a0e-b50a-8c704b5d0388" />

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [x] I have read and followed the [plugin contribution guidelines](https://kestra.io/docs/plugin-developer-guide/contribution-guidelines)
