### PR TITLE
feat(ssh): introduce new proxyCommand property

### DIFF
--- a/src/main/java/io/kestra/plugin/fs/ssh/SshInterface.java
+++ b/src/main/java/io/kestra/plugin/fs/ssh/SshInterface.java
@@ -60,6 +60,12 @@ public interface SshInterface {
     )
     Property<String> getOpenSSHConfigPath();
 
+    @Schema(
+        title = "Proxy command",
+        description = "Optional local command used to establish the SSH transport (OpenSSH `ProxyCommand` semantics)."
+    )
+    Property<String> getProxyCommand();
+
     enum AuthMethod {
         PASSWORD,
         PUBLIC_KEY,


### PR DESCRIPTION
closes https://github.com/kestra-io/plugin-fs/issues/195

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

#### Non regression

Flow:

```yaml
id: ssh_command_no_proxy_non_regression
namespace: company.team

tasks:
  - id: run_direct_ssh
    type: io.kestra.plugin.fs.ssh.Command
    host: localhost
    port: "2222"
    username: foo
    authMethod: PASSWORD
    password: "{{ secret('SSH_PASSWORD') }}"
    commands:
      - echo "hello direct ssh"
      - whoami
      - echo '::{\"outputs\":{\"mode\":\"direct\"}}::'
```

Results:

<img width="3188" height="673" alt="image" src="https://github.com/user-attachments/assets/170f13ec-1c70-46e6-9df6-e3b192464410" />

#### Flow with a proxyCommand

Flow:

```yaml
id: ssh_proxy_command_smoke
namespace: company.team

tasks:
  - id: run_via_proxy
    type: io.kestra.plugin.fs.ssh.Command
    host: unreachable.invalid
    port: "2222"
    username: foo
    authMethod: PASSWORD
    password: "{{ secret('SSH_PASSWORD') }}"
    proxyCommand: "nc 127.0.0.1 2222"
    commands:
      - echo "hello via proxy"
      - whoami
      - echo '::{\"outputs\":{\"proxy\":\"ok\"}}::
```

Results:

<img width="3188" height="673" alt="image" src="https://github.com/user-attachments/assets/6339e32e-0747-47e0-8bc9-ddc31f150a03" />

Removing the `proxyCommand` makes the execution fails as expected too. Flow:

```yaml
id: ssh_proxy_command_smoke
namespace: company.team

tasks:
  - id: run_via_proxy
    type: io.kestra.plugin.fs.ssh.Command
    host: unreachable.invalid
    port: "2222"
    username: foo
    authMethod: PASSWORD
    password: "{{ secret('SSH_PASSWORD') }}"
    commands:
      - echo "hello via proxy"
      - whoami
      - echo '::{\"outputs\":{\"proxy\":\"ok\"}}::
```

Results:

<img width="3188" height="673" alt="image" src="https://github.com/user-attachments/assets/3f089aae-e66d-4a83-8d5a-d3f0c3096937" />

This proves proxy routing.

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [x] I have read and followed the [plugin contribution guidelines](https://kestra.io/docs/plugin-developer-guide/contribution-guidelines)
