### PR TITLE
feat(uploads): support map-based from to preserve original filenames

### DIFF
--- a/src/main/java/io/kestra/plugin/fs/sftp/Uploads.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Uploads.java
@@ -18,37 +18,64 @@ import java.io.IOException;
 @Getter
 @NoArgsConstructor
 @Schema(
-        title = "Upload multiple files via SFTP",
-        description = "Uploads each provided file to the target directory. Defaults: port 22, user home as root, password auth unless a PEM key is provided, host key checking disabled by default."
+    title = "Upload multiple files via SFTP",
+    description = "Uploads each provided file to the target directory. Defaults: port 22, user home as root, password auth unless a PEM key is provided, host key checking disabled by default."
 )
 @Plugin(
-        examples = {
-                @Example(
-                        full = true,
-                        code = """
-                            id: fs_sftp_uploads
-                            namespace: company.team
+    examples = {
+        @Example(
+            title = "Upload files using a list of URIs",
+            full = true,
+            code = """
+                id: fs_sftp_uploads
+                namespace: company.team
 
-                            inputs:
-                              - id: file1
-                                type: FILE
-                              - id: file2
-                                type: FILE
-            
-                            tasks:
-                              - id: uploads
-                                type: io.kestra.plugin.fs.sftp.Uploads
-                                host: localhost
-                                port: "22"
-                                username: foo
-                                password: "{{ secret('SFTP_PASSWORD') }}"
-                                from:
-                                  - "{{ inputs.file1 }}"
-                                  - "{{ inputs.file2 }}"
-                                to: "/upload/dir2"
-                            """
-                )
-        }
+                inputs:
+                  - id: file1
+                    type: FILE
+                  - id: file2
+                    type: FILE
+
+                tasks:
+                  - id: uploads
+                    type: io.kestra.plugin.fs.sftp.Uploads
+                    host: localhost
+                    port: "22"
+                    username: foo
+                    password: "{{ secret('SFTP_PASSWORD') }}"
+                    from:
+                      - "{{ inputs.file1 }}"
+                      - "{{ inputs.file2 }}"
+                    to: "/upload/dir2"
+                """
+        ),
+        @Example(
+            title = "Upload files with custom destination filenames using a map",
+            full = true,
+            code = """
+                id: fs_sftp_uploads_with_names
+                namespace: company.team
+
+                inputs:
+                  - id: file1
+                    type: FILE
+                  - id: file2
+                    type: FILE
+
+                tasks:
+                  - id: uploads
+                    type: io.kestra.plugin.fs.sftp.Uploads
+                    host: localhost
+                    port: "22"
+                    username: foo
+                    password: "{{ secret('SFTP_PASSWORD') }}"
+                    from:
+                      report.csv: "{{ inputs.file1 }}"
+                      data.json: "{{ inputs.file2 }}"
+                    to: "/upload/dir2"
+                """
+        )
+    }
 )
 public class Uploads extends io.kestra.plugin.fs.vfs.Uploads implements SftpInterface {
     protected Property<String> keyfile;

--- a/src/main/java/io/kestra/plugin/fs/vfs/Uploads.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/Uploads.java
@@ -13,8 +13,8 @@ import lombok.experimental.SuperBuilder;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 
 import java.net.URI;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -33,14 +33,14 @@ public abstract class Uploads extends AbstractVfsTask implements RunnableTask<Up
             List.class,
             Map.class
         },
-        description = "Kestra internal storage URIs; accepts a single URI string, a list of URIs, or a URI pointing to a file that contains URIs."
+        description = "Kestra internal storage URIs; accepts a single URI string, a list of URIs, a map of destination filenames to URIs (to preserve original filenames), or a URI pointing to a file that contains URIs."
     )
     @PluginProperty(dynamic = true, internalStorageURI = true)
     @NotNull
     private Object from;
 
     @Schema(
-            title = "Destination directory"
+        title = "Destination directory"
     )
     @NotNull
     private Property<String> to;
@@ -56,22 +56,35 @@ public abstract class Uploads extends AbstractVfsTask implements RunnableTask<Up
             fsm.setConfiguration(StandardFileSystemManager.class.getResource(KestraStandardFileSystemManager.CONFIG_RESOURCE));
             fsm.init();
 
-            String[] renderedFrom = parseFromProperty(runContext);
+            // Each entry maps a destination filename (or null) to a source URI
+            java.util.List<Map.Entry<String, String>> fileMappings = parseFromProperty(runContext);
 
             int rMaxFiles = runContext.render(this.maxFiles).as(Integer.class).orElse(25);
-            if (renderedFrom.length > rMaxFiles) {
-                runContext.logger().warn("Too many files to process ({}), limiting to {}", renderedFrom.length, rMaxFiles);
-                renderedFrom = Arrays.copyOf(renderedFrom, rMaxFiles);
+            if (fileMappings.size() > rMaxFiles) {
+                runContext.logger().warn("Too many files to process ({}), limiting to {}", fileMappings.size(), rMaxFiles);
+                fileMappings = fileMappings.subList(0, rMaxFiles);
             }
 
-            List<Upload.Output> outputs = Arrays.stream(renderedFrom).map(throwFunction(fromURI -> {
+            java.util.List<Upload.Output> outputs = fileMappings.stream().map(throwFunction(entry -> {
+                String destFileName = entry.getKey();
+                String fromURI = entry.getValue();
                 var rTo = runContext.render(this.to).as(String.class).orElseThrow();
+
+                String destPath;
+                if (destFileName != null) {
+                    // Map-based: use the provided filename
+                    destPath = rTo + (rTo.endsWith("/") ? "" : "/") + destFileName;
+                } else {
+                    // List/String-based: use the URI's last segment (existing behavior)
+                    destPath = rTo + fromURI.substring(fromURI.lastIndexOf('/') + (rTo.endsWith("/") ? 1 : 0));
+                }
+
                 return VfsService.upload(
                     runContext,
                     fsm,
                     this.fsOptions(runContext),
                     URI.create(fromURI),
-                    this.uri(runContext, rTo + fromURI.substring(fromURI.lastIndexOf('/') + (rTo.endsWith("/") ? 1 : 0)))
+                    this.uri(runContext, destPath)
                 );
             })).toList();
 
@@ -84,29 +97,43 @@ public abstract class Uploads extends AbstractVfsTask implements RunnableTask<Up
         }
     }
 
-    private String[] parseFromProperty(RunContext runContext) throws Exception {
-        if (this.from instanceof String from) {
-            var rFrom = runContext.render(from).trim();
+    @SuppressWarnings("unchecked")
+    private java.util.List<Map.Entry<String, String>> parseFromProperty(RunContext runContext) throws Exception {
+        if (this.from instanceof Map<?, ?> fromMap) {
+            return ((Map<String, String>) fromMap).entrySet().stream()
+                .map(throwFunction(e -> new SimpleEntry<>(
+                    runContext.render(e.getKey()),
+                    runContext.render(e.getValue())
+                )))
+                .map(e -> (Map.Entry<String, String>) e)
+                .toList();
+        }
+
+        if (this.from instanceof String fromStr) {
+            var rFrom = runContext.render(fromStr).trim();
 
             if (rFrom.startsWith("[") && rFrom.endsWith("]")) {
-                return JacksonMapper.ofJson().readValue(rFrom, String[].class);
+                String[] uris = JacksonMapper.ofJson().readValue(rFrom, String[].class);
+                return Arrays.stream(uris)
+                    .<Map.Entry<String, String>>map(uri -> new SimpleEntry<>(null, uri))
+                    .toList();
             }
         }
 
         return Objects.requireNonNull(Data.from(this.from)
-                .readAs(runContext, String.class, Object::toString)
-                .map(throwFunction(runContext::render))
-                .collectList()
-                .block())
-            .toArray(String[]::new);
+            .readAs(runContext, String.class, Object::toString)
+            .map(throwFunction(runContext::render))
+            .<Map.Entry<String, String>>map(uri -> new SimpleEntry<>(null, uri))
+            .collectList()
+            .block());
     }
 
     @Builder
     @Getter
     public static class Output implements io.kestra.core.models.tasks.Output {
         @Schema(
-                title = "The fully-qualified URIs that point to the uploaded files on remote"
+            title = "The fully-qualified URIs that point to the uploaded files on remote"
         )
-        private List<URI> files;
+        private java.util.List<URI> files;
     }
 }

--- a/src/test/java/io/kestra/plugin/fs/sftp/UploadsTest.java
+++ b/src/test/java/io/kestra/plugin/fs/sftp/UploadsTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import static io.kestra.plugin.fs.sftp.SftpUtils.PASSWORD;
 import static io.kestra.plugin.fs.sftp.SftpUtils.USERNAME;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
@@ -29,6 +30,41 @@ class UploadsTest {
     private SftpUtils sftpUtils;
 
     private final String random = IdUtils.create();
+
+    @Test
+    void run_withMapShouldPreserveFilenames() throws Exception {
+        URI uri1 = sftpUtils.uploadToStorage();
+        URI uri2 = sftpUtils.uploadToStorage();
+        Uploads uploads = Uploads.builder()
+            .id(UploadsTest.class.getSimpleName())
+            .type(UploadsTest.class.getName())
+            .from(Map.of("report.csv", uri1.toString(), "data.json", uri2.toString()))
+            .to(Property.ofValue("/upload/" + random))
+            .host(Property.ofValue("localhost"))
+            .port(Property.ofValue("6622"))
+            .username(USERNAME)
+            .password(PASSWORD)
+            .build();
+        Output uploadsRun = uploads.run(TestsUtils.mockRunContext(runContextFactory, uploads, Map.of()));
+
+        assertThat(uploadsRun.getFiles().size(), is(2));
+        List<String> filePaths = uploadsRun.getFiles().stream().map(URI::getPath).toList();
+        assertThat(filePaths.stream().anyMatch(p -> p.endsWith("/report.csv")), is(true));
+        assertThat(filePaths.stream().anyMatch(p -> p.endsWith("/data.json")), is(true));
+
+        // Cleanup
+        Downloads task = Downloads.builder()
+            .id(UploadsTest.class.getSimpleName())
+            .type(UploadsTest.class.getName())
+            .from(Property.ofValue("/upload/" + random + "/"))
+            .action(Property.ofValue(Downloads.Action.DELETE))
+            .host(Property.ofValue("localhost"))
+            .port(Property.ofValue("6622"))
+            .username(USERNAME)
+            .password(PASSWORD)
+            .build();
+        task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()));
+    }
 
     @Test
     void run() throws Exception {


### PR DESCRIPTION
## Summary
- When `from` is provided as a `Map<String, String>` (filename → kestra:// URI), uploaded files now use the map keys as destination filenames instead of the random internal storage URI segments
- Existing `List` and `String` inputs are unchanged (backward compatible)
- Added a second example to the SFTP `Uploads` plugin showing map-based usage

## Test plan
- [ ] Existing `run()` test passes (List-based uploads unchanged)
- [ ] New `run_withMapShouldPreserveFilenames()` test verifies files are uploaded with the specified names (`report.csv`, `data.json`)

## QA

Run the sftp server locally with `docker run -p 2222:22 -d atmoz/sftp foo:pass:::upload`

Then:

```yaml
id: qa_sftp_uploads_map
namespace: company.team

inputs:
  - id: file1
    type: FILE
  - id: file2
    type: FILE

tasks:
  - id: upload_with_map
    type: io.kestra.plugin.fs.sftp.Uploads
    host: localhost
    port: "22"
    username: foo
    password: "{{ secret('SFTP_PASSWORD') }}"
    from:
      report.csv: "{{ inputs.file1 }}"
      data.json: "{{ inputs.file2 }}"
    to: "/upload/qa-map"

  - id: list_uploaded
    type: io.kestra.plugin.fs.sftp.List
    host: localhost
    port: "22"
    username: foo
    password: "{{ secret('SFTP_PASSWORD') }}"
    from: "/upload/qa-map/"

  - id: verify
    type: io.kestra.plugin.core.log.Log
    message: |
      Uploaded files: {{ outputs.upload_with_map.files }}
      Listed files: {{ outputs.list_uploaded.files }}
```

<img width="3209" height="1513" alt="image" src="https://github.com/user-attachments/assets/7867ff46-e309-4b0b-865c-52013594748d" />

Original names can now be found in the outputs:

<img width="2080" height="977" alt="image" src="https://github.com/user-attachments/assets/e482de0a-9fd3-46e3-9c38-065525ff4f63" />

<img width="2080" height="977" alt="image" src="https://github.com/user-attachments/assets/a2779a60-1bd6-4817-8903-700568e2bb5e" />

fixes https://app.usepylon.com/support/issues/views/36469f3c-64a7-47dc-8e82-9d36026bfc31?issueNumber=1429&view=fs 