### PR TITLE
feat: add checksum validation for downloads

### DIFF
--- a/src/main/java/io/kestra/plugin/fs/local/Download.java
+++ b/src/main/java/io/kestra/plugin/fs/local/Download.java
@@ -6,6 +6,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.FileUtils;
+import io.kestra.plugin.fs.vfs.ChecksumService;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -53,6 +54,21 @@ import io.kestra.core.models.annotations.PluginProperty;
                     from: "/data/files/source.csv"
                     workerGroup: "etl-worker"
                 """
+        ),
+        @Example(
+            title = "Download a local file and fail if its SHA-256 checksum does not match",
+            full = true,
+            code = """
+                id: fs_local_download_checksum
+                namespace: company.team
+
+                tasks:
+                  - id: download
+                    type: io.kestra.plugin.fs.local.Download
+                    from: "/data/files/source.csv"
+                    validateChecksum: true
+                    checksumExpected: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                """
         )
     }
 )
@@ -65,6 +81,29 @@ public class Download extends AbstractLocalTask implements RunnableTask<Download
     @NotNull
     @PluginProperty(group = "main")
     private Property<String> from;
+
+    @Schema(
+        title = "Validate the downloaded file against an expected checksum",
+        description = "When enabled, the task fails if the computed checksum does not match `checksumExpected`. The downloaded file is not stored in internal storage if validation fails."
+    )
+    @Builder.Default
+    @PluginProperty(group = "advanced")
+    private Property<Boolean> validateChecksum = Property.ofValue(false);
+
+    @Schema(
+        title = "Expected checksum value to compare against the downloaded file",
+        description = "Required when `validateChecksum` is `true`. Comparison is case-insensitive."
+    )
+    @PluginProperty(group = "advanced")
+    private Property<String> checksumExpected;
+
+    @Schema(
+        title = "Checksum algorithm to use",
+        description = "Defaults to `SHA_256`. The computed checksum is always exposed on the output as `checksum`."
+    )
+    @Builder.Default
+    @PluginProperty(group = "advanced")
+    private Property<ChecksumService.Algorithm> checksumAlgorithm = Property.ofValue(ChecksumService.Algorithm.SHA_256);
 
     @Override
     public Output run(RunContext runContext) throws Exception {
@@ -85,11 +124,20 @@ public class Download extends AbstractLocalTask implements RunnableTask<Download
         File tempFile = runContext.workingDir().createTempFile(extension).toFile();
         Files.copy(sourcePath, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
+        boolean rValidateChecksum = runContext.render(this.validateChecksum).as(Boolean.class).orElse(false);
+        String rChecksumExpected = runContext.render(this.checksumExpected).as(String.class).orElse(null);
+        ChecksumService.Algorithm rChecksumAlgorithm = runContext.render(this.checksumAlgorithm).as(ChecksumService.Algorithm.class).orElse(ChecksumService.Algorithm.SHA_256);
+
+        String checksum = rValidateChecksum
+            ? ChecksumService.verify(tempFile.toPath(), rChecksumAlgorithm, rChecksumExpected)
+            : ChecksumService.compute(tempFile.toPath(), rChecksumAlgorithm);
+
         URI storageUri = runContext.storage().putFile(tempFile);
 
         return Output.builder()
             .uri(storageUri)
             .size(Files.size(sourcePath))
+            .checksum(checksum)
             .build();
     }
 
@@ -105,5 +153,11 @@ public class Download extends AbstractLocalTask implements RunnableTask<Download
             title = "Size of the downloaded file in bytes"
         )
         private Long size;
+
+        @Schema(
+            title = "Checksum of the downloaded file",
+            description = "Hex-encoded digest computed with `checksumAlgorithm`. Populated whenever the file is downloaded successfully."
+        )
+        private String checksum;
     }
 }

--- a/src/main/java/io/kestra/plugin/fs/smb/Download.java
+++ b/src/main/java/io/kestra/plugin/fs/smb/Download.java
@@ -5,6 +5,7 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.fs.vfs.ChecksumService;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -37,6 +38,25 @@ import io.kestra.core.models.annotations.PluginProperty;
                     password: "{{ secret('SMB_PASSWORD') }}"
                     from: "/my_share/file.txt"
                 """
+        ),
+        @Example(
+            title = "Download a file and fail if its SHA-256 checksum does not match",
+            full = true,
+            code = """
+                id: fs_smb_download_checksum
+                namespace: company.team
+
+                tasks:
+                  - id: download
+                    type: io.kestra.plugin.fs.smb.Download
+                    host: localhost
+                    port: "445"
+                    username: foo
+                    password: "{{ secret('SMB_PASSWORD') }}"
+                    from: "/my_share/file.txt"
+                    validateChecksum: true
+                    checksumExpected: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                """
         )
     }
 )
@@ -48,14 +68,44 @@ public class Download extends AbstractSmbTask implements RunnableTask<io.kestra.
     @PluginProperty(group = "main")
     protected Property<String> from;
 
+    @Schema(
+        title = "Validate the downloaded file against an expected checksum",
+        description = "When enabled, the task fails if the computed checksum does not match `checksumExpected`. The downloaded file is not stored in internal storage if validation fails."
+    )
+    @Builder.Default
+    @PluginProperty(group = "advanced")
+    protected Property<Boolean> validateChecksum = Property.ofValue(false);
+
+    @Schema(
+        title = "Expected checksum value to compare against the downloaded file",
+        description = "Required when `validateChecksum` is `true`. Comparison is case-insensitive."
+    )
+    @PluginProperty(group = "advanced")
+    protected Property<String> checksumExpected;
+
+    @Schema(
+        title = "Checksum algorithm to use",
+        description = "Defaults to `SHA_256`. The computed checksum is always exposed on the output as `checksum`."
+    )
+    @Builder.Default
+    @PluginProperty(group = "advanced")
+    protected Property<ChecksumService.Algorithm> checksumAlgorithm = Property.ofValue(ChecksumService.Algorithm.SHA_256);
+
     public io.kestra.plugin.fs.vfs.Download.Output run(RunContext runContext) throws Exception {
         var ctx = createContext(runContext);
         try {
+            boolean rValidateChecksum = runContext.render(this.validateChecksum).as(Boolean.class).orElse(false);
+            String rChecksumExpected = runContext.render(this.checksumExpected).as(String.class).orElse(null);
+            ChecksumService.Algorithm rChecksumAlgorithm = runContext.render(this.checksumAlgorithm).as(ChecksumService.Algorithm.class).orElse(ChecksumService.Algorithm.SHA_256);
+
             return SmbService.download(
                 runContext,
                 ctx,
                 this,
-                runContext.render(this.from).as(String.class).orElseThrow()
+                runContext.render(this.from).as(String.class).orElseThrow(),
+                rValidateChecksum,
+                rChecksumExpected,
+                rChecksumAlgorithm
             );
         } finally {
             ctx.close();

--- a/src/main/java/io/kestra/plugin/fs/smb/Download.java
+++ b/src/main/java/io/kestra/plugin/fs/smb/Download.java
@@ -98,7 +98,7 @@ public class Download extends AbstractSmbTask implements RunnableTask<io.kestra.
             String rChecksumExpected = runContext.render(this.checksumExpected).as(String.class).orElse(null);
             ChecksumService.Algorithm rChecksumAlgorithm = runContext.render(this.checksumAlgorithm).as(ChecksumService.Algorithm.class).orElse(ChecksumService.Algorithm.SHA_256);
 
-            return SmbService.download(
+            return SmbService.download(new SmbDownloadRequest(
                 runContext,
                 ctx,
                 this,
@@ -106,7 +106,7 @@ public class Download extends AbstractSmbTask implements RunnableTask<io.kestra.
                 rValidateChecksum,
                 rChecksumExpected,
                 rChecksumAlgorithm
-            );
+            ));
         } finally {
             ctx.close();
         }

--- a/src/main/java/io/kestra/plugin/fs/smb/Downloads.java
+++ b/src/main/java/io/kestra/plugin/fs/smb/Downloads.java
@@ -118,12 +118,12 @@ public class Downloads extends AbstractSmbTask implements RunnableTask<Downloads
 
             var list = files.stream()
                 .map(throwFunction(file -> {
-                    var download = SmbService.download(
+                    var download = SmbService.download(SmbDownloadRequest.of(
                         runContext,
                         ctx,
                         this,
                         file.getServerPath().getPath()
-                    );
+                    ));
 
                     logger.debug("File '{}' download to '{}'", fromPath, download.getTo());
 

--- a/src/main/java/io/kestra/plugin/fs/smb/SmbDownloadRequest.java
+++ b/src/main/java/io/kestra/plugin/fs/smb/SmbDownloadRequest.java
@@ -1,0 +1,38 @@
+package io.kestra.plugin.fs.smb;
+
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.fs.vfs.ChecksumService;
+import org.codelibs.jcifs.smb.CIFSContext;
+
+public record SmbDownloadRequest(
+    RunContext runContext,
+    CIFSContext cifsContext,
+    SmbInterface smbInterface,
+    String filepath,
+    boolean validateChecksum,
+    String checksumExpected,
+    ChecksumService.Algorithm checksumAlgorithm
+) {
+    public SmbDownloadRequest {
+        if (checksumAlgorithm == null) {
+            checksumAlgorithm = ChecksumService.Algorithm.SHA_256;
+        }
+    }
+
+    public static SmbDownloadRequest of(
+        RunContext runContext,
+        CIFSContext cifsContext,
+        SmbInterface smbInterface,
+        String filepath
+    ) {
+        return new SmbDownloadRequest(
+            runContext,
+            cifsContext,
+            smbInterface,
+            filepath,
+            false,
+            null,
+            ChecksumService.Algorithm.SHA_256
+        );
+    }
+}

--- a/src/main/java/io/kestra/plugin/fs/smb/SmbService.java
+++ b/src/main/java/io/kestra/plugin/fs/smb/SmbService.java
@@ -155,6 +155,18 @@ public abstract class SmbService {
         SmbInterface smbInterface,
         String filepath
     ) throws Exception {
+        return download(runContext, cifsContext, smbInterface, filepath, false, null, io.kestra.plugin.fs.vfs.ChecksumService.Algorithm.SHA_256);
+    }
+
+    public static io.kestra.plugin.fs.vfs.Download.Output download(
+        RunContext runContext,
+        CIFSContext cifsContext,
+        SmbInterface smbInterface,
+        String filepath,
+        boolean validateChecksum,
+        String checksumExpected,
+        io.kestra.plugin.fs.vfs.ChecksumService.Algorithm checksumAlgorithm
+    ) throws Exception {
         var url = smbUrl(runContext, smbInterface, filepath);
         var ext = FileUtils.getExtension(filepath);
         var tempFile = runContext.workingDir().createTempFile(ext).toFile();
@@ -164,6 +176,11 @@ public abstract class SmbService {
              var out = new FileOutputStream(tempFile)) {
             IOUtils.copy(in, out);
         }
+
+        var algorithm = checksumAlgorithm != null ? checksumAlgorithm : io.kestra.plugin.fs.vfs.ChecksumService.Algorithm.SHA_256;
+        var checksum = validateChecksum
+            ? io.kestra.plugin.fs.vfs.ChecksumService.verify(tempFile.toPath(), algorithm, checksumExpected)
+            : io.kestra.plugin.fs.vfs.ChecksumService.compute(tempFile.toPath(), algorithm);
 
         var storageUri = runContext.storage().putFile(tempFile);
 
@@ -176,6 +193,7 @@ public abstract class SmbService {
         return io.kestra.plugin.fs.vfs.Download.Output.builder()
             .from(fromUri)
             .to(storageUri)
+            .checksum(checksum)
             .build();
     }
 

--- a/src/main/java/io/kestra/plugin/fs/smb/SmbService.java
+++ b/src/main/java/io/kestra/plugin/fs/smb/SmbService.java
@@ -149,38 +149,24 @@ public abstract class SmbService {
         }
     }
 
-    public static io.kestra.plugin.fs.vfs.Download.Output download(
-        RunContext runContext,
-        CIFSContext cifsContext,
-        SmbInterface smbInterface,
-        String filepath
-    ) throws Exception {
-        return download(runContext, cifsContext, smbInterface, filepath, false, null, io.kestra.plugin.fs.vfs.ChecksumService.Algorithm.SHA_256);
-    }
+    public static io.kestra.plugin.fs.vfs.Download.Output download(SmbDownloadRequest request) throws Exception {
+        RunContext runContext = request.runContext();
+        SmbInterface smbInterface = request.smbInterface();
+        String filepath = request.filepath();
 
-    public static io.kestra.plugin.fs.vfs.Download.Output download(
-        RunContext runContext,
-        CIFSContext cifsContext,
-        SmbInterface smbInterface,
-        String filepath,
-        boolean validateChecksum,
-        String checksumExpected,
-        io.kestra.plugin.fs.vfs.ChecksumService.Algorithm checksumAlgorithm
-    ) throws Exception {
         var url = smbUrl(runContext, smbInterface, filepath);
         var ext = FileUtils.getExtension(filepath);
         var tempFile = runContext.workingDir().createTempFile(ext).toFile();
 
-        try (var remote = new SmbFile(url, cifsContext);
+        try (var remote = new SmbFile(url, request.cifsContext());
              var in = remote.getInputStream();
              var out = new FileOutputStream(tempFile)) {
             IOUtils.copy(in, out);
         }
 
-        var algorithm = checksumAlgorithm != null ? checksumAlgorithm : io.kestra.plugin.fs.vfs.ChecksumService.Algorithm.SHA_256;
-        var checksum = validateChecksum
-            ? io.kestra.plugin.fs.vfs.ChecksumService.verify(tempFile.toPath(), algorithm, checksumExpected)
-            : io.kestra.plugin.fs.vfs.ChecksumService.compute(tempFile.toPath(), algorithm);
+        var checksum = request.validateChecksum()
+            ? io.kestra.plugin.fs.vfs.ChecksumService.verify(tempFile.toPath(), request.checksumAlgorithm(), request.checksumExpected())
+            : io.kestra.plugin.fs.vfs.ChecksumService.compute(tempFile.toPath(), request.checksumAlgorithm());
 
         var storageUri = runContext.storage().putFile(tempFile);
 

--- a/src/main/java/io/kestra/plugin/fs/smb/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/smb/Trigger.java
@@ -288,12 +288,12 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
 
             // 1) Download first, do NOT update state yet.
             for (PendingFile pending : limitedPending) {
-                var download = SmbService.download(
+                var download = SmbService.download(SmbDownloadRequest.of(
                     runContext,
                     ctx,
                     this,
                     pending.file.getServerPath().getPath()
-                );
+                ));
 
                 logger.debug("File '{}' download to '{}'", fromPath, download.getTo());
 

--- a/src/main/java/io/kestra/plugin/fs/vfs/ChecksumService.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/ChecksumService.java
@@ -1,0 +1,75 @@
+package io.kestra.plugin.fs.vfs;
+
+import io.kestra.core.exceptions.KestraRuntimeException;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public final class ChecksumService {
+
+    private static final int BUFFER_SIZE = 8 * 1024;
+
+    private ChecksumService() {
+    }
+
+    public enum Algorithm {
+        MD5("MD5"),
+        SHA_1("SHA-1"),
+        SHA_256("SHA-256"),
+        SHA_512("SHA-512");
+
+        private final String jcaName;
+
+        Algorithm(String jcaName) {
+            this.jcaName = jcaName;
+        }
+
+        public String jcaName() {
+            return jcaName;
+        }
+    }
+
+    public static String compute(Path file, Algorithm algorithm) throws IOException {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance(algorithm.jcaName());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Unsupported checksum algorithm: " + algorithm.jcaName(), e);
+        }
+
+        try (InputStream in = new BufferedInputStream(Files.newInputStream(file), BUFFER_SIZE);
+             DigestInputStream digestIn = new DigestInputStream(in, digest)) {
+            byte[] buffer = new byte[BUFFER_SIZE];
+            while (digestIn.read(buffer) != -1) {
+                // streaming — DigestInputStream updates the digest
+            }
+        }
+
+        return HexFormat.of().formatHex(digest.digest());
+    }
+
+    public static String verify(Path file, Algorithm algorithm, String expected) throws IOException {
+        if (expected == null || expected.isBlank()) {
+            throw new KestraRuntimeException(
+                "Checksum validation is enabled but no `checksumExpected` value was provided."
+            );
+        }
+
+        String computed = compute(file, algorithm);
+        if (!computed.equalsIgnoreCase(expected.trim())) {
+            throw new KestraRuntimeException(String.format(
+                "Checksum mismatch for file '%s' — expected '%s' but computed '%s' using %s.",
+                file, expected, computed, algorithm.jcaName()
+            ));
+        }
+
+        return computed;
+    }
+}

--- a/src/main/java/io/kestra/plugin/fs/vfs/Download.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/Download.java
@@ -57,7 +57,7 @@ public abstract class Download extends AbstractVfsTask implements RunnableTask<D
             String rChecksumExpected = runContext.render(this.checksumExpected).as(String.class).orElse(null);
             ChecksumService.Algorithm rChecksumAlgorithm = runContext.render(this.checksumAlgorithm).as(ChecksumService.Algorithm.class).orElse(ChecksumService.Algorithm.SHA_256);
 
-            return VfsService.download(
+            return VfsService.download(new VfsDownloadRequest(
                 runContext,
                 fsm,
                 this.fsOptions(runContext),
@@ -65,7 +65,7 @@ public abstract class Download extends AbstractVfsTask implements RunnableTask<D
                 rValidateChecksum,
                 rChecksumExpected,
                 rChecksumAlgorithm
-            );
+            ));
         }
     }
 

--- a/src/main/java/io/kestra/plugin/fs/vfs/Download.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/Download.java
@@ -25,16 +25,46 @@ public abstract class Download extends AbstractVfsTask implements RunnableTask<D
     @PluginProperty(group = "main")
     protected Property<String> from;
 
+    @Schema(
+        title = "Validate the downloaded file against an expected checksum",
+        description = "When enabled, the task fails if the computed checksum does not match `checksumExpected`. The downloaded file is not stored in internal storage if validation fails."
+    )
+    @Builder.Default
+    @PluginProperty(group = "advanced")
+    protected Property<Boolean> validateChecksum = Property.ofValue(false);
+
+    @Schema(
+        title = "Expected checksum value to compare against the downloaded file",
+        description = "Required when `validateChecksum` is `true`. Comparison is case-insensitive."
+    )
+    @PluginProperty(group = "advanced")
+    protected Property<String> checksumExpected;
+
+    @Schema(
+        title = "Checksum algorithm to use",
+        description = "Defaults to `SHA_256`. The computed checksum is always exposed on the output as `checksum`."
+    )
+    @Builder.Default
+    @PluginProperty(group = "advanced")
+    protected Property<ChecksumService.Algorithm> checksumAlgorithm = Property.ofValue(ChecksumService.Algorithm.SHA_256);
+
     public Output run(RunContext runContext) throws Exception {
         try (StandardFileSystemManager fsm = new KestraStandardFileSystemManager(runContext)) {
             fsm.setConfiguration(StandardFileSystemManager.class.getResource(KestraStandardFileSystemManager.CONFIG_RESOURCE));
             fsm.init();
 
+            boolean rValidateChecksum = runContext.render(this.validateChecksum).as(Boolean.class).orElse(false);
+            String rChecksumExpected = runContext.render(this.checksumExpected).as(String.class).orElse(null);
+            ChecksumService.Algorithm rChecksumAlgorithm = runContext.render(this.checksumAlgorithm).as(ChecksumService.Algorithm.class).orElse(ChecksumService.Algorithm.SHA_256);
+
             return VfsService.download(
                 runContext,
                 fsm,
                 this.fsOptions(runContext),
-                this.uri(runContext, runContext.render(this.from).as(String.class).orElseThrow())
+                this.uri(runContext, runContext.render(this.from).as(String.class).orElseThrow()),
+                rValidateChecksum,
+                rChecksumExpected,
+                rChecksumAlgorithm
             );
         }
     }
@@ -51,5 +81,11 @@ public abstract class Download extends AbstractVfsTask implements RunnableTask<D
             title = "The fully-qualified URIs that point to destination path"
         )
         private URI to;
+
+        @Schema(
+            title = "Checksum of the downloaded file",
+            description = "Hex-encoded digest computed with `checksumAlgorithm`. Populated whenever the file is downloaded successfully."
+        )
+        private String checksum;
     }
 }

--- a/src/main/java/io/kestra/plugin/fs/vfs/Downloads.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/Downloads.java
@@ -101,7 +101,7 @@ public abstract class Downloads extends AbstractVfsTask implements RunnableTask<
             java.util.List<io.kestra.plugin.fs.vfs.models.File> list = files
                 .stream()
                 .map(throwFunction(file -> {
-                    Download.Output download = VfsService.download(
+                    Download.Output download = VfsService.download(VfsDownloadRequest.of(
                         runContext,
                         fsm,
                         fileSystemOptions,
@@ -114,7 +114,7 @@ public abstract class Downloads extends AbstractVfsTask implements RunnableTask<
                             runContext.render(this.password).as(String.class).orElse(null),
                             file.getServerPath().getPath()
                         )
-                    );
+                    ));
 
                     logger.debug("File '{}' download to '{}'", from.getPath(), download.getTo());
 

--- a/src/main/java/io/kestra/plugin/fs/vfs/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/Trigger.java
@@ -207,7 +207,7 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
 
             // 1) Download first, do NOT update state yet.
             for (PendingFile pending : limitedPending) {
-                Download.Output download = VfsService.download(
+                Download.Output download = VfsService.download(VfsDownloadRequest.of(
                     runContext,
                     fsm,
                     fileSystemOptions,
@@ -220,7 +220,7 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
                         runContext.render(this.password).as(String.class).orElse(null),
                         pending.file.getServerPath().getPath()
                     )
-                );
+                ));
 
                 logger.debug("File '{}' download to '{}'", from.getPath(), download.getTo());
 

--- a/src/main/java/io/kestra/plugin/fs/vfs/VfsDownloadRequest.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/VfsDownloadRequest.java
@@ -1,0 +1,40 @@
+package io.kestra.plugin.fs.vfs;
+
+import io.kestra.core.runners.RunContext;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.impl.StandardFileSystemManager;
+
+import java.net.URI;
+
+public record VfsDownloadRequest(
+    RunContext runContext,
+    StandardFileSystemManager fsm,
+    FileSystemOptions fileSystemOptions,
+    URI from,
+    boolean validateChecksum,
+    String checksumExpected,
+    ChecksumService.Algorithm checksumAlgorithm
+) {
+    public VfsDownloadRequest {
+        if (checksumAlgorithm == null) {
+            checksumAlgorithm = ChecksumService.Algorithm.SHA_256;
+        }
+    }
+
+    public static VfsDownloadRequest of(
+        RunContext runContext,
+        StandardFileSystemManager fsm,
+        FileSystemOptions fileSystemOptions,
+        URI from
+    ) {
+        return new VfsDownloadRequest(
+            runContext,
+            fsm,
+            fileSystemOptions,
+            from,
+            false,
+            null,
+            ChecksumService.Algorithm.SHA_256
+        );
+    }
+}

--- a/src/main/java/io/kestra/plugin/fs/vfs/VfsService.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/VfsService.java
@@ -126,37 +126,21 @@ public abstract class VfsService {
         }
     }
 
-    public static Download.Output download(
-        RunContext runContext,
-        StandardFileSystemManager fsm,
-        FileSystemOptions fileSystemOptions,
-        URI from
-    ) throws Exception {
-        return download(runContext, fsm, fileSystemOptions, from, false, null, ChecksumService.Algorithm.SHA_256);
-    }
-
-    public static Download.Output download(
-        RunContext runContext,
-        StandardFileSystemManager fsm,
-        FileSystemOptions fileSystemOptions,
-        URI from,
-        boolean validateChecksum,
-        String checksumExpected,
-        ChecksumService.Algorithm checksumAlgorithm
-    ) throws Exception {
+    public static Download.Output download(VfsDownloadRequest request) throws Exception {
+        RunContext runContext = request.runContext();
+        URI from = request.from();
         java.io.File tempFile = runContext.workingDir().createTempFile(FileUtils.getExtension(from)).toFile();
 
         try (
-            FileObject local = fsm.resolveFile(tempFile.toURI());
-            FileObject remote = fsm.resolveFile(from.toString(), fileSystemOptions)
+            FileObject local = request.fsm().resolveFile(tempFile.toURI());
+            FileObject remote = request.fsm().resolveFile(from.toString(), request.fileSystemOptions())
         ) {
             local.copyFrom(remote, Selectors.SELECT_SELF);
         }
 
-        ChecksumService.Algorithm algorithm = checksumAlgorithm != null ? checksumAlgorithm : ChecksumService.Algorithm.SHA_256;
-        String checksum = validateChecksum
-            ? ChecksumService.verify(tempFile.toPath(), algorithm, checksumExpected)
-            : ChecksumService.compute(tempFile.toPath(), algorithm);
+        String checksum = request.validateChecksum()
+            ? ChecksumService.verify(tempFile.toPath(), request.checksumAlgorithm(), request.checksumExpected())
+            : ChecksumService.compute(tempFile.toPath(), request.checksumAlgorithm());
 
         URI storageUri = runContext.storage().putFile(tempFile);
 

--- a/src/main/java/io/kestra/plugin/fs/vfs/VfsService.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/VfsService.java
@@ -132,6 +132,18 @@ public abstract class VfsService {
         FileSystemOptions fileSystemOptions,
         URI from
     ) throws Exception {
+        return download(runContext, fsm, fileSystemOptions, from, false, null, ChecksumService.Algorithm.SHA_256);
+    }
+
+    public static Download.Output download(
+        RunContext runContext,
+        StandardFileSystemManager fsm,
+        FileSystemOptions fileSystemOptions,
+        URI from,
+        boolean validateChecksum,
+        String checksumExpected,
+        ChecksumService.Algorithm checksumAlgorithm
+    ) throws Exception {
         java.io.File tempFile = runContext.workingDir().createTempFile(FileUtils.getExtension(from)).toFile();
 
         try (
@@ -141,6 +153,11 @@ public abstract class VfsService {
             local.copyFrom(remote, Selectors.SELECT_SELF);
         }
 
+        ChecksumService.Algorithm algorithm = checksumAlgorithm != null ? checksumAlgorithm : ChecksumService.Algorithm.SHA_256;
+        String checksum = validateChecksum
+            ? ChecksumService.verify(tempFile.toPath(), algorithm, checksumExpected)
+            : ChecksumService.compute(tempFile.toPath(), algorithm);
+
         URI storageUri = runContext.storage().putFile(tempFile);
 
         runContext.logger().debug("File '{}' download to '{}'", VfsService.uriWithoutAuth(from), storageUri);
@@ -148,6 +165,7 @@ public abstract class VfsService {
         return Download.Output.builder()
             .from(VfsService.uriWithoutAuth(from))
             .to(storageUri)
+            .checksum(checksum)
             .build();
     }
 

--- a/src/test/java/io/kestra/plugin/fs/local/DownloadTest.java
+++ b/src/test/java/io/kestra/plugin/fs/local/DownloadTest.java
@@ -1,10 +1,12 @@
 package io.kestra.plugin.fs.local;
 
+import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.fs.vfs.ChecksumService;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +18,7 @@ import java.util.Comparator;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.*;
@@ -25,6 +28,10 @@ class DownloadTest {
 
     private Path sourceFile;
     private final String fileContent = "test content";
+    // SHA-256 of "test content"
+    private static final String FILE_CONTENT_SHA_256 = "6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72";
+    // MD5 of "test content"
+    private static final String FILE_CONTENT_MD5 = "9473fdd0d880a43c21b7778d34872157";
 
     @Inject
     private RunContextFactory runContextFactory;
@@ -57,6 +64,84 @@ class DownloadTest {
             StandardCharsets.UTF_8
         );
         assertThat(fileContent, is(storedContent));
+    }
+
+    @Test
+    void downloadComputesChecksumByDefault() throws Exception {
+        Download task = Download.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .from(Property.ofValue(sourceFile.toString()))
+            .build();
+
+        Download.Output output = task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()));
+
+        assertThat(output.getChecksum(), is(FILE_CONTENT_SHA_256));
+    }
+
+    @Test
+    void downloadWithValidChecksum() throws Exception {
+        Download task = Download.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .from(Property.ofValue(sourceFile.toString()))
+            .validateChecksum(Property.ofValue(true))
+            .checksumExpected(Property.ofValue(FILE_CONTENT_SHA_256))
+            .build();
+
+        Download.Output output = task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()));
+
+        assertThat(output.getUri(), notNullValue());
+        assertThat(output.getChecksum(), is(FILE_CONTENT_SHA_256));
+    }
+
+    @Test
+    void downloadChecksumMismatchFails() {
+        Download task = Download.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .from(Property.ofValue(sourceFile.toString()))
+            .validateChecksum(Property.ofValue(true))
+            .checksumExpected(Property.ofValue("deadbeef"))
+            .build();
+
+        KestraRuntimeException ex = assertThrows(
+            KestraRuntimeException.class,
+            () -> task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()))
+        );
+        assertThat(ex.getMessage(), containsString("Checksum mismatch"));
+    }
+
+    @Test
+    void downloadValidateChecksumWithoutExpectedFails() {
+        Download task = Download.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .from(Property.ofValue(sourceFile.toString()))
+            .validateChecksum(Property.ofValue(true))
+            .build();
+
+        KestraRuntimeException ex = assertThrows(
+            KestraRuntimeException.class,
+            () -> task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()))
+        );
+        assertThat(ex.getMessage(), containsString("checksumExpected"));
+    }
+
+    @Test
+    void downloadWithMd5Algorithm() throws Exception {
+        Download task = Download.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .from(Property.ofValue(sourceFile.toString()))
+            .validateChecksum(Property.ofValue(true))
+            .checksumAlgorithm(Property.ofValue(ChecksumService.Algorithm.MD5))
+            .checksumExpected(Property.ofValue(FILE_CONTENT_MD5))
+            .build();
+
+        Download.Output output = task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()));
+
+        assertThat(output.getChecksum(), is(FILE_CONTENT_MD5));
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/fs/sftp/DownloadChecksumTest.java
+++ b/src/test/java/io/kestra/plugin/fs/sftp/DownloadChecksumTest.java
@@ -1,0 +1,135 @@
+package io.kestra.plugin.fs.sftp;
+
+import io.kestra.core.exceptions.KestraRuntimeException;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.fs.vfs.ChecksumService;
+import io.kestra.plugin.fs.vfs.Download.Output;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.Map;
+
+import static io.kestra.plugin.fs.sftp.SftpUtils.PASSWORD;
+import static io.kestra.plugin.fs.sftp.SftpUtils.USERNAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@KestraTest
+class DownloadChecksumTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    private SftpUtils sftpUtils;
+
+    private static final String CONTENT = "deterministic content for checksum tests";
+
+    private static String sha256(String value) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static String md5(String value) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("MD5");
+        return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private Download.DownloadBuilder<?, ?> downloadBuilder(String remotePath) {
+        return Download.builder()
+            .id(DownloadChecksumTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .from(Property.ofValue(remotePath))
+            .host(Property.ofValue("localhost"))
+            .port(Property.ofValue("6622"))
+            .username(USERNAME)
+            .password(PASSWORD);
+    }
+
+    private String uploadFixture() throws Exception {
+        String remotePath = "upload/" + IdUtils.create() + ".txt";
+        sftpUtils.update(remotePath, CONTENT);
+        return remotePath;
+    }
+
+    @Test
+    void downloadWithMatchingChecksum() throws Exception {
+        String remotePath = uploadFixture();
+
+        Download task = downloadBuilder(remotePath)
+            .validateChecksum(Property.ofValue(true))
+            .checksumExpected(Property.ofValue(sha256(CONTENT)))
+            .build();
+
+        Output output = task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()));
+
+        assertThat(output.getTo(), notNullValue());
+        assertThat(output.getChecksum(), is(sha256(CONTENT)));
+    }
+
+    @Test
+    void downloadChecksumMismatchFails() throws Exception {
+        String remotePath = uploadFixture();
+
+        Download task = downloadBuilder(remotePath)
+            .validateChecksum(Property.ofValue(true))
+            .checksumExpected(Property.ofValue("deadbeef"))
+            .build();
+
+        KestraRuntimeException ex = assertThrows(
+            KestraRuntimeException.class,
+            () -> task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()))
+        );
+        assertThat(ex.getMessage(), containsString("Checksum mismatch"));
+    }
+
+    @Test
+    void downloadValidateChecksumWithoutExpectedFails() throws Exception {
+        String remotePath = uploadFixture();
+
+        Download task = downloadBuilder(remotePath)
+            .validateChecksum(Property.ofValue(true))
+            .build();
+
+        KestraRuntimeException ex = assertThrows(
+            KestraRuntimeException.class,
+            () -> task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()))
+        );
+        assertThat(ex.getMessage(), containsString("checksumExpected"));
+    }
+
+    @Test
+    void downloadWithoutValidationStillExposesChecksum() throws Exception {
+        String remotePath = uploadFixture();
+
+        Download task = downloadBuilder(remotePath).build();
+
+        Output output = task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()));
+
+        assertThat(output.getChecksum(), is(sha256(CONTENT)));
+    }
+
+    @Test
+    void downloadWithMd5Algorithm() throws Exception {
+        String remotePath = uploadFixture();
+
+        Download task = downloadBuilder(remotePath)
+            .validateChecksum(Property.ofValue(true))
+            .checksumAlgorithm(Property.ofValue(ChecksumService.Algorithm.MD5))
+            .checksumExpected(Property.ofValue(md5(CONTENT)))
+            .build();
+
+        Output output = task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()));
+
+        assertThat(output.getChecksum(), is(md5(CONTENT)));
+    }
+}

--- a/src/test/java/io/kestra/plugin/fs/smb/DownloadChecksumTest.java
+++ b/src/test/java/io/kestra/plugin/fs/smb/DownloadChecksumTest.java
@@ -1,0 +1,135 @@
+package io.kestra.plugin.fs.smb;
+
+import io.kestra.core.exceptions.KestraRuntimeException;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.fs.vfs.ChecksumService;
+import io.kestra.plugin.fs.vfs.Download.Output;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.Map;
+
+import static io.kestra.plugin.fs.smb.SmbUtils.PASSWORD;
+import static io.kestra.plugin.fs.smb.SmbUtils.USERNAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@KestraTest
+class DownloadChecksumTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    private SmbUtils smbUtils;
+
+    private static final String CONTENT = "deterministic content for checksum tests";
+
+    private static String sha256(String value) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static String md5(String value) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("MD5");
+        return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private Download.DownloadBuilder<?, ?> downloadBuilder(String remotePath) {
+        return Download.builder()
+            .id(DownloadChecksumTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .from(Property.ofValue(remotePath))
+            .host(Property.ofValue("localhost"))
+            .port(Property.ofValue("445"))
+            .username(USERNAME)
+            .password(PASSWORD);
+    }
+
+    private String uploadFixture() throws Exception {
+        String remotePath = "/" + SmbUtils.SHARE_NAME + "/" + IdUtils.create() + ".txt";
+        smbUtils.update(remotePath, CONTENT);
+        return remotePath;
+    }
+
+    @Test
+    void downloadWithMatchingChecksum() throws Exception {
+        String remotePath = uploadFixture();
+
+        Download task = downloadBuilder(remotePath)
+            .validateChecksum(Property.ofValue(true))
+            .checksumExpected(Property.ofValue(sha256(CONTENT)))
+            .build();
+
+        Output output = task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()));
+
+        assertThat(output.getTo(), notNullValue());
+        assertThat(output.getChecksum(), is(sha256(CONTENT)));
+    }
+
+    @Test
+    void downloadChecksumMismatchFails() throws Exception {
+        String remotePath = uploadFixture();
+
+        Download task = downloadBuilder(remotePath)
+            .validateChecksum(Property.ofValue(true))
+            .checksumExpected(Property.ofValue("deadbeef"))
+            .build();
+
+        KestraRuntimeException ex = assertThrows(
+            KestraRuntimeException.class,
+            () -> task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()))
+        );
+        assertThat(ex.getMessage(), containsString("Checksum mismatch"));
+    }
+
+    @Test
+    void downloadValidateChecksumWithoutExpectedFails() throws Exception {
+        String remotePath = uploadFixture();
+
+        Download task = downloadBuilder(remotePath)
+            .validateChecksum(Property.ofValue(true))
+            .build();
+
+        KestraRuntimeException ex = assertThrows(
+            KestraRuntimeException.class,
+            () -> task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()))
+        );
+        assertThat(ex.getMessage(), containsString("checksumExpected"));
+    }
+
+    @Test
+    void downloadWithoutValidationStillExposesChecksum() throws Exception {
+        String remotePath = uploadFixture();
+
+        Download task = downloadBuilder(remotePath).build();
+
+        Output output = task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()));
+
+        assertThat(output.getChecksum(), is(sha256(CONTENT)));
+    }
+
+    @Test
+    void downloadWithMd5Algorithm() throws Exception {
+        String remotePath = uploadFixture();
+
+        Download task = downloadBuilder(remotePath)
+            .validateChecksum(Property.ofValue(true))
+            .checksumAlgorithm(Property.ofValue(ChecksumService.Algorithm.MD5))
+            .checksumExpected(Property.ofValue(md5(CONTENT)))
+            .build();
+
+        Output output = task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()));
+
+        assertThat(output.getChecksum(), is(md5(CONTENT)));
+    }
+}

--- a/src/test/java/io/kestra/plugin/fs/vfs/ChecksumServiceTest.java
+++ b/src/test/java/io/kestra/plugin/fs/vfs/ChecksumServiceTest.java
@@ -1,0 +1,94 @@
+package io.kestra.plugin.fs.vfs;
+
+import io.kestra.core.exceptions.KestraRuntimeException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ChecksumServiceTest {
+
+    // SHA-256 of "hello world"
+    private static final String HELLO_WORLD_SHA_256 = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+    // MD5 of "hello world"
+    private static final String HELLO_WORLD_MD5 = "5eb63bbbe01eeed093cb22bb8f5acdc3";
+
+    @TempDir
+    private Path tempDir;
+
+    private Path file;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        file = tempDir.resolve("input.txt");
+        Files.writeString(file, "hello world", StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void computeSha256() throws IOException {
+        String computed = ChecksumService.compute(file, ChecksumService.Algorithm.SHA_256);
+        assertThat(computed, is(HELLO_WORLD_SHA_256));
+    }
+
+    @Test
+    void computeMd5() throws IOException {
+        String computed = ChecksumService.compute(file, ChecksumService.Algorithm.MD5);
+        assertThat(computed, is(HELLO_WORLD_MD5));
+    }
+
+    @Test
+    void verifyMatchReturnsComputedDigest() throws IOException {
+        String result = ChecksumService.verify(file, ChecksumService.Algorithm.SHA_256, HELLO_WORLD_SHA_256);
+        assertThat(result, is(HELLO_WORLD_SHA_256));
+    }
+
+    @Test
+    void verifyIsCaseInsensitive() throws IOException {
+        String result = ChecksumService.verify(file, ChecksumService.Algorithm.SHA_256, HELLO_WORLD_SHA_256.toUpperCase());
+        assertThat(result, equalToIgnoringCase(HELLO_WORLD_SHA_256));
+    }
+
+    @Test
+    void verifyTrimsExpectedValue() throws IOException {
+        String result = ChecksumService.verify(file, ChecksumService.Algorithm.SHA_256, "  " + HELLO_WORLD_SHA_256 + "  ");
+        assertThat(result, is(HELLO_WORLD_SHA_256));
+    }
+
+    @Test
+    void verifyMismatchFails() {
+        KestraRuntimeException ex = assertThrows(
+            KestraRuntimeException.class,
+            () -> ChecksumService.verify(file, ChecksumService.Algorithm.SHA_256, "deadbeef")
+        );
+        assertThat(ex.getMessage(), containsString("Checksum mismatch"));
+        assertThat(ex.getMessage(), containsString("deadbeef"));
+        assertThat(ex.getMessage(), containsString(HELLO_WORLD_SHA_256));
+    }
+
+    @Test
+    void verifyMissingExpectedFails() {
+        KestraRuntimeException ex = assertThrows(
+            KestraRuntimeException.class,
+            () -> ChecksumService.verify(file, ChecksumService.Algorithm.SHA_256, null)
+        );
+        assertThat(ex.getMessage(), containsString("checksumExpected"));
+    }
+
+    @Test
+    void verifyBlankExpectedFails() {
+        assertThrows(
+            KestraRuntimeException.class,
+            () -> ChecksumService.verify(file, ChecksumService.Algorithm.SHA_256, "   ")
+        );
+    }
+}


### PR DESCRIPTION
part of https://github.com/kestra-io/kestra-ee/issues/5699

Only download part in the PR, wait for answer on issue to know how to handle upload part.

### QA

flow used (sftp server run locally with command `docker compose -f docker-compose-ci.yml up  sftp` ): 

``` yaml
id: fs_checksum_test
namespace: company.team

tasks:
  - id: create_file
    type: io.kestra.plugin.core.storage.Write
    content: |
      hello world
    extension: .txt

  - id: upload
    type: io.kestra.plugin.fs.sftp.Upload
    host: localhost
    port: "6622"
    username: foo
    password: "pass*+="
    from: "{{ outputs.create_file.uri }}"
    to: "/upload/hello.txt"
  
  # 1. Download with correct SHA-256 ? should succeed and expose `checksum`
  - id: download_ok
    type: io.kestra.plugin.fs.sftp.Download
    host: localhost
    port: "6622"
    username: foo
    password: "pass*+="
    from: "/upload/hello.txt"
    validateChecksum: true
    checksumAlgorithm: SHA_256
    checksumExpected: "a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447"
  
  # 2. Download without validation ? just exposes the computed checksum on the output
  - id: download_compute_only
    type: io.kestra.plugin.fs.sftp.Download
    host: localhost
    port: "6622"
    username: foo
    password: "pass*+="
    from: "/upload/hello.txt"
    checksumAlgorithm: MD5
  
  # 3. Download with WRONG checksum ? should fail the task with a clear message
  - id: download_should_fail
    type: io.kestra.plugin.fs.sftp.Download
    host: localhost
    port: "6622"
    username: foo
    password: "pass*+="
    from: "/upload/hello.txt"
    validateChecksum: true
    checksumExpected: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
    allowFailure: true

````

<img width="2346" height="592" alt="image" src="https://github.com/user-attachments/assets/3bd18e5c-22a4-4a92-aae5-95a46a8e0f23" />
