### PR TITLE
fix(triggers): always fire on MOVE/DELETE so re-uploaded files are not suppressed

### DIFF
--- a/src/main/java/io/kestra/plugin/fs/vfs/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/Trigger.java
@@ -129,6 +129,7 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
         // fire, regardless of persisted state. Stateful dedup only applies when the file stays (action NONE).
         var eligibleStates = java.util.List.of(Downloads.Action.DELETE, Downloads.Action.MOVE);
         var shouldRemoveFiles = eligibleStates.contains(rAction);
+        var stateful = !shouldRemoveFiles;   // NONE keeps files in place, so dedup relies on persisted state
         var rStateKey = runContext.render(stateKey)
             .as(String.class)
             .orElse(StatefulTriggerService.defaultKey(context.getNamespace(), context.getFlowId(), id));
@@ -169,7 +170,7 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
                 .filter(file -> file.getFileType() == FileType.FILE)
                 .toList();
 
-            Map<String, Entry> state = shouldRemoveFiles ? new HashMap<>() : readState(runContext, rStateKey, rStateTtl);
+            Map<String, Entry> state = stateful ? readState(runContext, rStateKey, rStateTtl) : new HashMap<>();
 
             java.util.List<PendingFile> pendingFiles = new ArrayList<>();
 
@@ -212,10 +213,7 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
 
             if (limitedPending.isEmpty()) {
                 // still persist state for files we skipped / updated above
-                if (!shouldRemoveFiles) {
-                    writeState(runContext, rStateKey, state, rStateTtl);
-                }
-                return Optional.empty();
+                return noFire(stateful, runContext, rStateKey, state, rStateTtl);
             }
 
             java.util.List<File> actionFiles = new ArrayList<>();
@@ -251,10 +249,7 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
 
             if (toFire.isEmpty()) {
                 // nothing to fire; persist state updates made earlier
-                if (!shouldRemoveFiles) {
-                    writeState(runContext, rStateKey, state, rStateTtl);
-                }
-                return Optional.empty();
+                return noFire(stateful, runContext, rStateKey, state, rStateTtl);
             }
 
             // 2) Perform remote action BEFORE committing state.
@@ -279,7 +274,7 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
 
             // 3) Only now that downloads + actions succeeded, commit state for fired files.
             //    MOVE/DELETE removed the files, so there is no state to track.
-            if (!shouldRemoveFiles) {
+            if (stateful) {
                 for (PendingFile pending : limitedPending) {
                     computeAndUpdateState(state, pending.candidate, rOn);
                 }
@@ -296,6 +291,14 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
 
             return Optional.of(execution);
         }
+    }
+
+    // Persists pending state updates (a no-op for MOVE/DELETE) and signals that nothing fired this poll.
+    private Optional<Execution> noFire(boolean stateful, RunContext runContext, String stateKey, Map<String, Entry> state, Optional<Duration> stateTtl) {
+        if (stateful) {
+            writeState(runContext, stateKey, state, stateTtl);
+        }
+        return Optional.empty();
     }
 
     private URI createUri(RunContext runContext) throws IllegalVariableEvaluationException, URISyntaxException {

--- a/src/main/java/io/kestra/plugin/fs/vfs/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/Trigger.java
@@ -122,6 +122,11 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
         );
 
         var rOn = runContext.render(on).as(On.class).orElse(On.CREATE_OR_UPDATE);
+        var renderedAction = runContext.render(this.action).as(Downloads.Action.class).orElse(Downloads.Action.NONE);
+        // MOVE/DELETE remove the file from the watched location after processing, so the action itself
+        // prevents reprocessing. Any file still present in the listing is therefore genuinely new and must
+        // fire, regardless of persisted state. Stateful dedup only applies when the file stays (action NONE).
+        var removesFiles = renderedAction == Downloads.Action.MOVE || renderedAction == Downloads.Action.DELETE;
         var rStateKey = runContext.render(stateKey)
             .as(String.class)
             .orElse(StatefulTriggerService.defaultKey(context.getNamespace(), context.getFlowId(), id));
@@ -162,7 +167,7 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
                 .filter(file -> file.getFileType() == FileType.FILE)
                 .toList();
 
-            Map<String, Entry> state = readState(runContext, rStateKey, rStateTtl);
+            Map<String, Entry> state = removesFiles ? new java.util.HashMap<>() : readState(runContext, rStateKey, rStateTtl);
 
             java.util.List<PendingFile> pendingFiles = new ArrayList<>();
 
@@ -177,6 +182,13 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
                 var version = String.format("%d_%d_%s", updatedDate.toEpochMilli(), size, remotePath);
 
                 var candidate = Entry.candidate(remotePath, version, updatedDate);
+
+                // MOVE/DELETE: the file is removed after processing, so always fire; do not consult state.
+                if (removesFiles) {
+                    pendingFiles.add(new PendingFile(file, candidate, ChangeType.CREATE));
+                    continue;
+                }
+
                 var prev = state.get(remotePath);
 
                 // IMPORTANT: keep state up to date for non-fired files
@@ -198,7 +210,9 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
 
             if (limitedPending.isEmpty()) {
                 // still persist state for files we skipped / updated above
-                writeState(runContext, rStateKey, state, rStateTtl);
+                if (!removesFiles) {
+                    writeState(runContext, rStateKey, state, rStateTtl);
+                }
                 return Optional.empty();
             }
 
@@ -235,14 +249,14 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
 
             if (toFire.isEmpty()) {
                 // nothing to fire; persist state updates made earlier
-                writeState(runContext, rStateKey, state, rStateTtl);
+                if (!removesFiles) {
+                    writeState(runContext, rStateKey, state, rStateTtl);
+                }
                 return Optional.empty();
             }
 
             // 2) Perform remote action BEFORE committing state.
-            if (this.action != null) {
-                var renderedAction = runContext.render(this.action).as(Downloads.Action.class).orElse(null);
-
+            if (removesFiles) {
                 VfsService.performAction(
                     runContext,
                     fsm,
@@ -262,11 +276,14 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
             }
 
             // 3) Only now that downloads + actions succeeded, commit state for fired files.
-            for (PendingFile pending : limitedPending) {
-                computeAndUpdateState(state, pending.candidate, rOn);
-            }
+            //    MOVE/DELETE removed the files, so there is no state to track.
+            if (!removesFiles) {
+                for (PendingFile pending : limitedPending) {
+                    computeAndUpdateState(state, pending.candidate, rOn);
+                }
 
-            writeState(runContext, rStateKey, state, rStateTtl);
+                writeState(runContext, rStateKey, state, rStateTtl);
+            }
 
             Execution execution = TriggerService.generateExecution(
                 this,

--- a/src/main/java/io/kestra/plugin/fs/vfs/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/Trigger.java
@@ -25,6 +25,7 @@ import java.net.URISyntaxException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -53,7 +54,7 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
     @PluginProperty(group = "main")
     private Property<String> from;
 
-    @Schema(title = "Action to perform on retrieved files", description = "If NONE, handle files in the Flow to avoid reprocessing.")
+    @Schema(title = "Action to perform on retrieved files", description = "MOVE/DELETE remove the file from the watched directory, so the trigger fires on every listed file. NONE leaves the file in place and relies on stateful deduplication (path + size + last-modified) to avoid reprocessing — handle the file in the Flow accordingly.")
     @NotNull
     private Property<Downloads.Action> action;
 
@@ -122,11 +123,12 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
         );
 
         var rOn = runContext.render(on).as(On.class).orElse(On.CREATE_OR_UPDATE);
-        var renderedAction = runContext.render(this.action).as(Downloads.Action.class).orElse(Downloads.Action.NONE);
+        var rAction = runContext.render(this.action).as(Downloads.Action.class).orElse(Downloads.Action.NONE);
         // MOVE/DELETE remove the file from the watched location after processing, so the action itself
         // prevents reprocessing. Any file still present in the listing is therefore genuinely new and must
         // fire, regardless of persisted state. Stateful dedup only applies when the file stays (action NONE).
-        var removesFiles = renderedAction == Downloads.Action.MOVE || renderedAction == Downloads.Action.DELETE;
+        var eligibleStates = java.util.List.of(Downloads.Action.DELETE, Downloads.Action.MOVE);
+        var shouldRemoveFiles = eligibleStates.contains(rAction);
         var rStateKey = runContext.render(stateKey)
             .as(String.class)
             .orElse(StatefulTriggerService.defaultKey(context.getNamespace(), context.getFlowId(), id));
@@ -167,7 +169,7 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
                 .filter(file -> file.getFileType() == FileType.FILE)
                 .toList();
 
-            Map<String, Entry> state = removesFiles ? new java.util.HashMap<>() : readState(runContext, rStateKey, rStateTtl);
+            Map<String, Entry> state = shouldRemoveFiles ? new HashMap<>() : readState(runContext, rStateKey, rStateTtl);
 
             java.util.List<PendingFile> pendingFiles = new ArrayList<>();
 
@@ -184,7 +186,7 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
                 var candidate = Entry.candidate(remotePath, version, updatedDate);
 
                 // MOVE/DELETE: the file is removed after processing, so always fire; do not consult state.
-                if (removesFiles) {
+                if (shouldRemoveFiles) {
                     pendingFiles.add(new PendingFile(file, candidate, ChangeType.CREATE));
                     continue;
                 }
@@ -210,7 +212,7 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
 
             if (limitedPending.isEmpty()) {
                 // still persist state for files we skipped / updated above
-                if (!removesFiles) {
+                if (!shouldRemoveFiles) {
                     writeState(runContext, rStateKey, state, rStateTtl);
                 }
                 return Optional.empty();
@@ -249,20 +251,20 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
 
             if (toFire.isEmpty()) {
                 // nothing to fire; persist state updates made earlier
-                if (!removesFiles) {
+                if (!shouldRemoveFiles) {
                     writeState(runContext, rStateKey, state, rStateTtl);
                 }
                 return Optional.empty();
             }
 
             // 2) Perform remote action BEFORE committing state.
-            if (removesFiles) {
+            if (shouldRemoveFiles) {
                 VfsService.performAction(
                     runContext,
                     fsm,
                     fileSystemOptions,
                     actionFiles,
-                    renderedAction,
+                    rAction,
                     VfsService.uri(
                         runContext,
                         this.scheme(),
@@ -277,7 +279,7 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
 
             // 3) Only now that downloads + actions succeeded, commit state for fired files.
             //    MOVE/DELETE removed the files, so there is no state to track.
-            if (!removesFiles) {
+            if (!shouldRemoveFiles) {
                 for (PendingFile pending : limitedPending) {
                     computeAndUpdateState(state, pending.candidate, rOn);
                 }

--- a/src/test/java/io/kestra/plugin/fs/AbstractFileTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/fs/AbstractFileTriggerTest.java
@@ -56,6 +56,38 @@ public abstract class AbstractFileTriggerTest {
     }
 
     @Test
+    void deleteActionRefiresSamePath() throws Exception {
+        // Regression: with action DELETE the processed file is removed from the watched directory,
+        // so a file re-appearing at the SAME path is genuinely new and must fire on every poll.
+        // The stateful trigger previously remembered the path and silently suppressed re-uploads.
+        String toUploadDir = "/upload/trigger-delete-refire";
+        cleanupRemoteDir(toUploadDir);
+
+        // Fixed filename so the same remote path is reused across polls (the customer's case).
+        String fileName = "recurring-file";
+
+        var trigger = createTrigger(toUploadDir + "/", Downloads.Action.DELETE, null);
+        var context = TestsUtils.mockTrigger(runContextFactory, trigger);
+        var polling = (io.kestra.core.models.triggers.PollingTriggerInterface) trigger;
+
+        // First arrival -> fires and deletes the file.
+        utils().upload(toUploadDir + "/" + fileName);
+        Optional<Execution> first = polling.evaluate(context.getKey(), context.getValue());
+        assertThat(first.isPresent(), is(true));
+        assertThat(utils().list(toUploadDir).getFiles().isEmpty(), is(true));
+
+        // Same file uploaded again at the same path -> must fire again (state must not suppress it).
+        utils().upload(toUploadDir + "/" + fileName);
+        Optional<Execution> second = polling.evaluate(context.getKey(), context.getValue());
+        assertThat(second.isPresent(), is(true));
+
+        @SuppressWarnings("unchecked")
+        java.util.List<File> files = (java.util.List<File>) second.get().getTrigger().getVariables().get("files");
+        assertThat(files.size(), is(1));
+        assertThat(utils().list(toUploadDir).getFiles().isEmpty(), is(true));
+    }
+
+    @Test
     void noneAction() throws Exception {
         String toUploadDir = "/upload/trigger-none";
         cleanupRemoteDir(toUploadDir);


### PR DESCRIPTION
## Problem

After upgrading to a version that includes the stateful trigger (`#236`, shipped in plugin-fs **v1.1.0** — present in the Kestra 1.2.9 bundle), flows using `io.kestra.plugin.fs.ftp.Trigger` (and the other VFS protocols) **stop firing**.

Reported via Pylon issue #1874: a flow with `action: DELETE` watching a recurring `/WL.wips` upload triggered once, then went silent.

## Root cause

The stateful trigger deduplicates listed files by `path + size + mtime` and skips files it has already seen. That logic is wrong for `action: MOVE` / `action: DELETE`: those actions **remove the processed file from the watched directory**, so the removal itself is the dedup mechanism. When a file re-appears at the same path, the persisted state treated it as a duplicate and suppressed it.

`action: NONE` was unaffected — which is why it looked like FTP triggers were simply broken.

## Fix

In `vfs/Trigger.java` (shared by ftp/ftps/sftp/smb): when the rendered action is `MOVE` or `DELETE`, bypass the state read/write entirely and fire on every listed file. Stateful dedup now applies only to `action: NONE`, where the file stays in place. Side benefit: no more unbounded state growth from deleted files' paths.

## Tests

- Added `deleteActionRefiresSamePath()` to `AbstractFileTriggerTest` (runs for all protocols): upload fixed-name file → fire + delete → re-upload same path → assert it fires again.
- `ftp.TriggerTest` runs green (4/4) against a real vsftpd container, including the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)