### PR TITLE
fix(smb): clear error when upload/move target filename is invalid for SMB

### DIFF
--- a/src/main/java/io/kestra/plugin/fs/smb/SmbService.java
+++ b/src/main/java/io/kestra/plugin/fs/smb/SmbService.java
@@ -8,7 +8,9 @@ import io.kestra.plugin.fs.vfs.models.File;
 import org.codelibs.jcifs.smb.CIFSContext;
 import org.codelibs.jcifs.smb.context.BaseContext;
 import org.codelibs.jcifs.smb.config.PropertyConfiguration;
+import org.codelibs.jcifs.smb.impl.NtStatus;
 import org.codelibs.jcifs.smb.impl.NtlmPasswordAuthenticator;
+import org.codelibs.jcifs.smb.impl.SmbException;
 import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -235,6 +237,8 @@ public abstract class SmbService {
             try (var in = runContext.storage().getFile(from);
                  var out = remote.getOutputStream()) {
                 IOUtils.copy(in, out);
+            } catch (SmbException e) {
+                throw toActionableException(e, toPath);
             }
         }
 
@@ -398,12 +402,16 @@ public abstract class SmbService {
                 // Detect cross-share move: extract share names from URLs
                 var fromShare = extractShareName(fromUrl);
                 var toShare = extractShareName(toUrl);
-                if (fromShare != null && toShare != null && !fromShare.equals(toShare)) {
-                    // Cross-share move: renameTo won't work, use copy + delete
-                    copyRecursively(cifsContext, source, dest);
-                    deleteRecursively(source);
-                } else {
-                    source.renameTo(dest);
+                try {
+                    if (fromShare != null && toShare != null && !fromShare.equals(toShare)) {
+                        // Cross-share move: renameTo won't work, use copy + delete
+                        copyRecursively(cifsContext, source, dest);
+                        deleteRecursively(source);
+                    } else {
+                        source.renameTo(dest);
+                    }
+                } catch (SmbException e) {
+                    throw toActionableException(e, toPath);
                 }
             }
         }
@@ -534,6 +542,20 @@ public abstract class SmbService {
             }
         }
         return path;
+    }
+
+    private static Exception toActionableException(SmbException e, String targetPath) {
+        if (e.getNtStatus() == NtStatus.NT_STATUS_OBJECT_NAME_INVALID) {
+            return new KestraRuntimeException(String.format(
+                """
+                Path '%s' contains characters that are invalid in SMB/Windows file or directory names. \
+                Characters not allowed: \\ : * ? " < > |. \
+                If the path includes a timestamp, consider reformatting it to avoid colons (e.g. use 'T07-00-00' instead of 'T07:00:00').\
+                """,
+                targetPath
+            ), e);
+        }
+        return e;
     }
 
     static File smbFileToFile(SmbFile smbFile, String host, String port) throws Exception {

--- a/src/test/java/io/kestra/plugin/fs/smb/UploadTest.java
+++ b/src/test/java/io/kestra/plugin/fs/smb/UploadTest.java
@@ -20,6 +20,7 @@ import static io.kestra.plugin.fs.smb.SmbUtils.USERNAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
 
 @KestraTest
 class UploadTest {
@@ -102,6 +103,27 @@ class UploadTest {
         File file = listResult.getFiles().getFirst();
         assertThat(file.getName(), is(destinationFolder.replace("/","")));
         assertThat(file.getPath().toString(), containsString(parentFolder));
+    }
+
+    @Test
+    void upload_invalidFileNameCharacter_throwsClearError() throws Exception {
+        var storageUri = smbUtils.uploadToStorage();
+        var invalidDestination = SmbUtils.SHARE_NAME + "/invalidname" + IdUtils.create() + "/CLIENTES_2026-06-09T07:00:00.xlsx";
+
+        var upload = Upload.builder()
+            .id(IdUtils.create())
+            .type(Upload.class.getName())
+            .from(Property.ofValue(storageUri.toString()))
+            .to(Property.ofValue(invalidDestination))
+            .host(Property.ofValue("localhost"))
+            .username(USERNAME)
+            .password(PASSWORD)
+            .build();
+
+        var runContext = TestsUtils.mockRunContext(runContextFactory, upload, Map.of());
+        var exception = assertThrows(KestraRuntimeException.class, () -> upload.run(runContext));
+        assertThat(exception.getMessage(), containsString("CLIENTES_2026-06-09T07:00:00.xlsx"));
+        assertThat(exception.getMessage(), containsStringIgnoringCase("invalid"));
     }
 
     private void uploadFilesToRemoteFolder(String destinationFolder) throws Exception {


### PR DESCRIPTION
## Why

`smb.Upload` (and `smb.Move`) fail with the opaque message **"The filename, directory name, or volume label syntax is incorrect."** when the destination filename contains a character that is illegal on an SMB/Windows volume — most commonly a **colon** coming from a timestamp (e.g. `CLIENTES_2026-06-09T07:00:00.xlsx`). The jcifs layer surfaces the raw `NT_STATUS_OBJECT_NAME_INVALID` status with no indication of what's wrong, so users can't tell why an upload that "worked before" now fails.

Verified empirically against the project's Samba service: filenames with a space, `#`, or `?` upload fine; filenames with `:` or `*` are rejected by the server. The illegal characters (`\ : * ? " < > |`) cannot be made valid client-side, so the right fix is a clear, actionable error rather than silent transformation.

Fixes #318.

## What

- `SmbService.upload()` and `SmbService.move()` now catch the jcifs `SmbException` around the write/rename and, when `getNtStatus() == NtStatus.NT_STATUS_OBJECT_NAME_INVALID`, rethrow a `KestraRuntimeException` naming the offending path and the disallowed characters, with a hint to reformat timestamps (avoid colons). All other `SmbException`s pass through unchanged.
- No path encoding is introduced — the existing raw-path behavior (which already handles spaces, `#`, etc. correctly) is preserved.

## Test plan

- New test `UploadTest.upload_invalidFileNameCharacter_throwsClearError` uploads to a colon-containing filename and asserts a `KestraRuntimeException` whose message names the file and mentions the invalid characters. Confirmed RED before the change (raw `SmbException`) → GREEN after.
- Full SMB suite green (`./gradlew test --tests "io.kestra.plugin.fs.smb.*"`, 30 tests) — existing space/`#`/`?` upload, download, move, delete, list, and trigger tests unaffected.


🤖 Generated with [Claude Code](https://claude.com/claude-code)