### PR TITLE
fix(security): harden credential exposure and injection risks

### DIFF
--- a/src/main/java/io/kestra/plugin/fs/ftps/FtpsInterface.java
+++ b/src/main/java/io/kestra/plugin/fs/ftps/FtpsInterface.java
@@ -24,7 +24,7 @@ public interface FtpsInterface {
 
     @Schema(
         title = "Trust all certificates",
-        description = "Skip server certificate validation. Insecure; use only for testing."
+        description = "Skip server certificate validation. Insecure: this disables protection against man-in-the-middle attacks and must not be enabled in production. Use only for testing against self-signed or untrusted certificates."
     )
     @PluginProperty(group = "advanced")
     Property<Boolean> getInsecureTrustAllCertificates();

--- a/src/main/java/io/kestra/plugin/fs/ftps/FtpsService.java
+++ b/src/main/java/io/kestra/plugin/fs/ftps/FtpsService.java
@@ -30,6 +30,9 @@ public abstract class FtpsService {
         // instance.setKeyManager(options, null);
 
         if (runContext.render(ftpsInterface.getInsecureTrustAllCertificates()).as(Boolean.class).orElse(false)) {
+            runContext.logger().warn(
+                "`insecureTrustAllCertificates` is enabled: server certificate validation is disabled for this FTPS connection. This must not be used in production, only for testing against self-signed or untrusted certificates."
+            );
             instance.setTrustManager(options, new X509TrustManager() {
                 public X509Certificate[] getAcceptedIssuers() {
                     return null;

--- a/src/main/java/io/kestra/plugin/fs/local/Download.java
+++ b/src/main/java/io/kestra/plugin/fs/local/Download.java
@@ -99,7 +99,7 @@ public class Download extends AbstractLocalTask implements RunnableTask<Download
 
     @Schema(
         title = "Checksum algorithm to use",
-        description = "Defaults to `SHA_256`. The computed checksum is always exposed on the output as `checksum`."
+        description = "Defaults to `SHA_256`. The computed checksum is always exposed on the output as `checksum`. `MD5` and `SHA_1` are deprecated and considered weak; prefer `SHA_256` or `SHA_512`."
     )
     @Builder.Default
     @PluginProperty(group = "advanced")
@@ -127,6 +127,7 @@ public class Download extends AbstractLocalTask implements RunnableTask<Download
         boolean rValidateChecksum = runContext.render(this.validateChecksum).as(Boolean.class).orElse(false);
         String rChecksumExpected = runContext.render(this.checksumExpected).as(String.class).orElse(null);
         ChecksumService.Algorithm rChecksumAlgorithm = runContext.render(this.checksumAlgorithm).as(ChecksumService.Algorithm.class).orElse(ChecksumService.Algorithm.SHA_256);
+        ChecksumService.warnIfWeak(runContext.logger(), rChecksumAlgorithm);
 
         String checksum = rValidateChecksum
             ? ChecksumService.verify(tempFile.toPath(), rChecksumAlgorithm, rChecksumExpected)

--- a/src/main/java/io/kestra/plugin/fs/sftp/Delete.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Delete.java
@@ -43,8 +43,10 @@ import io.kestra.core.models.annotations.PluginProperty;
     }
 )
 public class Delete extends io.kestra.plugin.fs.vfs.Delete implements SftpInterface {
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> keyfile;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "advanced")
     protected Property<String> passphrase;
     @Deprecated
@@ -57,8 +59,10 @@ public class Delete extends io.kestra.plugin.fs.vfs.Delete implements SftpInterf
     @Deprecated
     @PluginProperty(group = "deprecated")
     protected Property<String> proxyUser;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyUsername;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyPassword;
     @PluginProperty(group = "advanced")

--- a/src/main/java/io/kestra/plugin/fs/sftp/Download.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Download.java
@@ -43,8 +43,10 @@ import io.kestra.core.models.annotations.PluginProperty;
     }
 )
 public class Download extends io.kestra.plugin.fs.vfs.Download implements SftpInterface {
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> keyfile;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "advanced")
     protected Property<String> passphrase;
     @Deprecated
@@ -57,8 +59,10 @@ public class Download extends io.kestra.plugin.fs.vfs.Download implements SftpIn
     @Deprecated
     @PluginProperty(group = "deprecated")
     protected Property<String> proxyUser;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyUsername;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyPassword;
     @PluginProperty(group = "advanced")

--- a/src/main/java/io/kestra/plugin/fs/sftp/Downloads.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Downloads.java
@@ -47,8 +47,10 @@ import io.kestra.core.models.annotations.PluginProperty;
     }
 )
 public class Downloads extends io.kestra.plugin.fs.vfs.Downloads implements SftpInterface {
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> keyfile;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "advanced")
     protected Property<String> passphrase;
     @Deprecated
@@ -61,8 +63,10 @@ public class Downloads extends io.kestra.plugin.fs.vfs.Downloads implements Sftp
     @Deprecated
     @PluginProperty(group = "deprecated")
     protected Property<String> proxyUser;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyUsername;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyPassword;
     @PluginProperty(group = "advanced")

--- a/src/main/java/io/kestra/plugin/fs/sftp/List.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/List.java
@@ -44,8 +44,10 @@ import io.kestra.core.models.annotations.PluginProperty;
     }
 )
 public class List extends io.kestra.plugin.fs.vfs.List implements SftpInterface {
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> keyfile;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "advanced")
     protected Property<String> passphrase;
     @Deprecated
@@ -58,8 +60,10 @@ public class List extends io.kestra.plugin.fs.vfs.List implements SftpInterface 
     @Deprecated
     @PluginProperty(group = "deprecated")
     protected Property<String> proxyUser;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyUsername;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyPassword;
     @PluginProperty(group = "advanced")

--- a/src/main/java/io/kestra/plugin/fs/sftp/Move.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Move.java
@@ -44,8 +44,10 @@ import io.kestra.core.models.annotations.PluginProperty;
     }
 )
 public class Move extends io.kestra.plugin.fs.vfs.Move implements SftpInterface {
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> keyfile;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "advanced")
     protected Property<String> passphrase;
     @Deprecated
@@ -58,8 +60,10 @@ public class Move extends io.kestra.plugin.fs.vfs.Move implements SftpInterface 
     @Deprecated
     @PluginProperty(group = "deprecated")
     protected Property<String> proxyUser;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyUsername;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyPassword;
     @PluginProperty(group = "advanced")

--- a/src/main/java/io/kestra/plugin/fs/sftp/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Trigger.java
@@ -121,8 +121,10 @@ import java.io.IOException;
     }
 )
 public class Trigger extends io.kestra.plugin.fs.vfs.Trigger implements SftpInterface {
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> keyfile;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "advanced")
     protected Property<String> passphrase;
     @Deprecated
@@ -135,8 +137,10 @@ public class Trigger extends io.kestra.plugin.fs.vfs.Trigger implements SftpInte
     @Deprecated
     @PluginProperty(group = "deprecated")
     protected Property<String> proxyUser;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyUsername;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyPassword;
     @PluginProperty(group = "advanced")

--- a/src/main/java/io/kestra/plugin/fs/sftp/Upload.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Upload.java
@@ -48,8 +48,10 @@ import io.kestra.core.models.annotations.PluginProperty;
     }
 )
 public class Upload extends io.kestra.plugin.fs.vfs.Upload implements SftpInterface {
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> keyfile;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "advanced")
     protected Property<String> passphrase;
     @Deprecated
@@ -62,8 +64,10 @@ public class Upload extends io.kestra.plugin.fs.vfs.Upload implements SftpInterf
     @Deprecated
     @PluginProperty(group = "deprecated")
     protected Property<String> proxyUser;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyUsername;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyPassword;
     @PluginProperty(group = "advanced")

--- a/src/main/java/io/kestra/plugin/fs/sftp/Uploads.java
+++ b/src/main/java/io/kestra/plugin/fs/sftp/Uploads.java
@@ -100,8 +100,10 @@ import io.kestra.core.models.annotations.PluginProperty;
     }
 )
 public class Uploads extends io.kestra.plugin.fs.vfs.Uploads implements SftpInterface {
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> keyfile;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "advanced")
     protected Property<String> passphrase;
     @Deprecated
@@ -114,8 +116,10 @@ public class Uploads extends io.kestra.plugin.fs.vfs.Uploads implements SftpInte
     @Deprecated
     @PluginProperty(group = "deprecated")
     protected Property<String> proxyUser;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyUsername;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> proxyPassword;
     @PluginProperty(group = "advanced")

--- a/src/main/java/io/kestra/plugin/fs/smb/AbstractSmbTask.java
+++ b/src/main/java/io/kestra/plugin/fs/smb/AbstractSmbTask.java
@@ -18,9 +18,11 @@ public abstract class AbstractSmbTask extends Task implements SmbInterface {
     @NotNull
     protected Property<String> host;
 
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> username;
 
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> password;
 

--- a/src/main/java/io/kestra/plugin/fs/smb/Download.java
+++ b/src/main/java/io/kestra/plugin/fs/smb/Download.java
@@ -85,7 +85,7 @@ public class Download extends AbstractSmbTask implements RunnableTask<io.kestra.
 
     @Schema(
         title = "Checksum algorithm to use",
-        description = "Defaults to `SHA_256`. The computed checksum is always exposed on the output as `checksum`."
+        description = "Defaults to `SHA_256`. The computed checksum is always exposed on the output as `checksum`. `MD5` and `SHA_1` are deprecated and considered weak; prefer `SHA_256` or `SHA_512`."
     )
     @Builder.Default
     @PluginProperty(group = "advanced")

--- a/src/main/java/io/kestra/plugin/fs/smb/SmbService.java
+++ b/src/main/java/io/kestra/plugin/fs/smb/SmbService.java
@@ -166,6 +166,7 @@ public abstract class SmbService {
             IOUtils.copy(in, out);
         }
 
+        io.kestra.plugin.fs.vfs.ChecksumService.warnIfWeak(runContext.logger(), request.checksumAlgorithm());
         var checksum = request.validateChecksum()
             ? io.kestra.plugin.fs.vfs.ChecksumService.verify(tempFile.toPath(), request.checksumAlgorithm(), request.checksumExpected())
             : io.kestra.plugin.fs.vfs.ChecksumService.compute(tempFile.toPath(), request.checksumAlgorithm());

--- a/src/main/java/io/kestra/plugin/fs/smb/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/smb/Trigger.java
@@ -147,8 +147,10 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
 
     @NotNull
     protected Property<String> host;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> username;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> password;
 

--- a/src/main/java/io/kestra/plugin/fs/ssh/Command.java
+++ b/src/main/java/io/kestra/plugin/fs/ssh/Command.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 
 @SuperBuilder
 @ToString
@@ -121,14 +122,18 @@ public class Command extends Task implements SshInterface, RunnableTask<Command.
     private Property<String> host;
 
     // Password Auth method
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     private Property<String> username;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     private Property<String> password;
 
     // PubKey Auth method
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     private Property<String> privateKey;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     private Property<String> privateKeyPassphrase;
 
@@ -393,6 +398,9 @@ public class Command extends Task implements SshInterface, RunnableTask<Command.
     }
 
     private static final class ProcessProxyCommand implements Proxy {
+        // %h/%p/%r are substituted verbatim into a shell command; only allow characters that cannot break out of it
+        private static final Pattern SAFE_VALUE = Pattern.compile("[a-zA-Z0-9._@-]+");
+
         private final String command;
         @PluginProperty(secret = true, group = "connection")
         private final String username;
@@ -408,10 +416,13 @@ public class Command extends Task implements SshInterface, RunnableTask<Command.
 
         @Override
         public void connect(SocketFactory socketFactory, String host, int port, int timeout) throws Exception {
+            var sanitizedHost = sanitize(host, "host");
+            var sanitizedUsername = username == null ? "" : sanitize(username, "username");
+
             var resolvedCommand = command
-                .replace("%h", host)
+                .replace("%h", sanitizedHost)
                 .replace("%p", String.valueOf(port))
-                .replace("%r", username == null ? "" : username);
+                .replace("%r", sanitizedUsername);
 
             var processBuilder = new ProcessBuilder(shellCommand(resolvedCommand));
             processBuilder.redirectError(ProcessBuilder.Redirect.DISCARD);
@@ -422,6 +433,15 @@ public class Command extends Task implements SshInterface, RunnableTask<Command.
             if (!process.isAlive()) {
                 throw new JSchException("Proxy command exited immediately: " + resolvedCommand);
             }
+        }
+
+        private static String sanitize(String value, String fieldName) {
+            if (!SAFE_VALUE.matcher(value).matches()) {
+                throw new IllegalArgumentException(
+                    "Invalid SSH " + fieldName + " '" + value + "': only letters, digits, '.', '_', '@' and '-' are allowed when a `proxyCommand` is configured, to prevent shell injection."
+                );
+            }
+            return value;
         }
 
         private static String[] shellCommand(String command) {

--- a/src/main/java/io/kestra/plugin/fs/tcp/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/fs/tcp/RealtimeTrigger.java
@@ -86,13 +86,13 @@ public class RealtimeTrigger extends AbstractTrigger
 
     private transient final AtomicBoolean active = new AtomicBoolean(false);
     private transient ServerSocket serverSocket;
+    private transient Logger logger;
 
     @Override
     public Publisher<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) throws Exception {
         RunContext runContext = conditionContext.getRunContext();
-        Logger logger = runContext.logger();
+        this.logger = runContext.logger();
 
-        
         String rHost = runContext.render(this.host).as(String.class).orElse("0.0.0.0");
         Integer rPort = runContext.render(this.port).as(Integer.class)
             .orElseThrow(() -> new IllegalArgumentException("`port` is required"));
@@ -167,16 +167,22 @@ public class RealtimeTrigger extends AbstractTrigger
                 if (serverSocket != null && !serverSocket.isClosed()) {
                     serverSocket.close();
                 }
-                System.out.println("[TcpRealtimeTrigger] Socket closed via stop()");
+                if (logger != null) {
+                    logger.info("TCP RealtimeTrigger socket closed via stop()");
+                }
             } catch (Exception e) {
-                System.out.println("[TcpRealtimeTrigger] Error closing socket: " + e.getMessage());
+                if (logger != null) {
+                    logger.warn("Error closing socket: {}", e.getMessage());
+                }
             }
         }
     }
 
     @Override
     public void kill() {
-        System.out.println("[TcpRealtimeTrigger] Kill signal received");
+        if (logger != null) {
+            logger.debug("TCP RealtimeTrigger kill signal received");
+        }
         stop();
     }
 
@@ -186,15 +192,11 @@ public class RealtimeTrigger extends AbstractTrigger
                 serverSocket.close();
                 if (logger != null && port != null) {
                     logger.info("TCP RealtimeTrigger stopped listening on port {}", port);
-                } else {
-                    System.out.println("[TcpRealtimeTrigger] Stopped listening on port " + port);
                 }
             }
         } catch (Exception e) {
             if (logger != null) {
                 logger.warn("Error closing server socket: {}", e.getMessage());
-            } else {
-                System.out.println("[TcpRealtimeTrigger] Error closing socket: " + e.getMessage());
             }
         }
     }

--- a/src/main/java/io/kestra/plugin/fs/udp/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/fs/udp/RealtimeTrigger.java
@@ -80,11 +80,12 @@ public class RealtimeTrigger extends AbstractTrigger
 
     private transient final AtomicBoolean active = new AtomicBoolean(false);
     private transient DatagramSocket socket;
+    private transient Logger logger;
 
     @Override
     public Publisher<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) throws Exception {
         RunContext runContext = conditionContext.getRunContext();
-        Logger logger = runContext.logger();
+        this.logger = runContext.logger();
 
         String rHost = runContext.render(this.host).as(String.class).orElse("0.0.0.0");
         Integer rPort = runContext.render(this.port).as(Integer.class)
@@ -151,7 +152,9 @@ public class RealtimeTrigger extends AbstractTrigger
                 try {
                     socket.close();
                 } catch (Exception e) {
-                    System.out.println("[UdpRealtimeTrigger] Error closing socket: " + e.getMessage());
+                    if (logger != null) {
+                        logger.warn("Error closing socket: {}", e.getMessage());
+                    }
                 }
             }
         }

--- a/src/main/java/io/kestra/plugin/fs/vfs/AbstractVfsTask.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/AbstractVfsTask.java
@@ -24,7 +24,10 @@ import io.kestra.core.models.annotations.PluginProperty;
 @NoArgsConstructor
 public abstract class AbstractVfsTask extends Task implements AbstractVfsInterface {
     protected Property<String> host;
+    @ToString.Exclude
     protected Property<String> username;
+    @ToString.Exclude
+    @PluginProperty(secret = true, group = "connection")
     protected Property<String> password;
 
     @Builder.Default

--- a/src/main/java/io/kestra/plugin/fs/vfs/ChecksumService.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/ChecksumService.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.fs.vfs;
 
 import io.kestra.core.exceptions.KestraRuntimeException;
+import org.slf4j.Logger;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -20,7 +21,15 @@ public final class ChecksumService {
     }
 
     public enum Algorithm {
+        /**
+         * @deprecated MD5 is cryptographically broken; prefer {@link #SHA_256} or {@link #SHA_512}.
+         */
+        @Deprecated
         MD5("MD5"),
+        /**
+         * @deprecated SHA-1 is no longer considered secure; prefer {@link #SHA_256} or {@link #SHA_512}.
+         */
+        @Deprecated
         SHA_1("SHA-1"),
         SHA_256("SHA-256"),
         SHA_512("SHA-512");
@@ -33,6 +42,15 @@ public final class ChecksumService {
 
         public String jcaName() {
             return jcaName;
+        }
+    }
+
+    public static void warnIfWeak(Logger logger, Algorithm algorithm) {
+        if (algorithm == Algorithm.MD5 || algorithm == Algorithm.SHA_1) {
+            logger.warn(
+                "Checksum algorithm '{}' is deprecated and considered weak; use SHA_256 or stronger for integrity verification.",
+                algorithm.jcaName()
+            );
         }
     }
 

--- a/src/main/java/io/kestra/plugin/fs/vfs/Download.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/Download.java
@@ -42,7 +42,7 @@ public abstract class Download extends AbstractVfsTask implements RunnableTask<D
 
     @Schema(
         title = "Checksum algorithm to use",
-        description = "Defaults to `SHA_256`. The computed checksum is always exposed on the output as `checksum`."
+        description = "Defaults to `SHA_256`. The computed checksum is always exposed on the output as `checksum`. `MD5` and `SHA_1` are deprecated and considered weak; prefer `SHA_256` or `SHA_512`."
     )
     @Builder.Default
     @PluginProperty(group = "advanced")

--- a/src/main/java/io/kestra/plugin/fs/vfs/Trigger.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/Trigger.java
@@ -44,8 +44,10 @@ public abstract class Trigger extends AbstractTrigger implements PollingTriggerI
     private final Duration interval = Duration.ofSeconds(60);
 
     protected Property<String> host;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> username;
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> password;
 

--- a/src/main/java/io/kestra/plugin/fs/vfs/VfsService.java
+++ b/src/main/java/io/kestra/plugin/fs/vfs/VfsService.java
@@ -138,6 +138,7 @@ public abstract class VfsService {
             local.copyFrom(remote, Selectors.SELECT_SELF);
         }
 
+        ChecksumService.warnIfWeak(runContext.logger(), request.checksumAlgorithm());
         String checksum = request.validateChecksum()
             ? ChecksumService.verify(tempFile.toPath(), request.checksumAlgorithm(), request.checksumExpected())
             : ChecksumService.compute(tempFile.toPath(), request.checksumAlgorithm());

--- a/src/test/java/io/kestra/plugin/fs/ftps/DownloadUploadTest.java
+++ b/src/test/java/io/kestra/plugin/fs/ftps/DownloadUploadTest.java
@@ -2,7 +2,10 @@ package io.kestra.plugin.fs.ftps;
 
 import com.google.common.base.Charsets;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
@@ -11,6 +14,7 @@ import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.fs.ftp.FtpUtils;
 import io.kestra.plugin.fs.vfs.models.File;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,6 +27,7 @@ import java.net.Socket;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static io.kestra.plugin.fs.ftp.FtpUtils.PASSWORD;
 import static io.kestra.plugin.fs.ftp.FtpUtils.USERNAME;
@@ -40,6 +45,10 @@ class DownloadUploadTest {
 
     @Inject
     private StorageInterface storageInterface;
+
+    @Inject
+    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
+    private QueueInterface<LogEntry> logQueue;
 
     @BeforeAll
     static void waitForFtps() throws Exception {
@@ -120,6 +129,33 @@ class DownloadUploadTest {
         assertThat(uploadsRun.getFiles().stream().map(URI::getPath).toList(), Matchers.everyItem(
                 Matchers.is(Matchers.in(remoteFileUris))
         ));
+    }
+
+    @Test
+    void insecureTrustAllCertificates_logsWarning() throws Exception {
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        var receive = TestsUtils.receive(logQueue, l -> logs.add(l.getLeft()));
+
+        URI uri = ftpUtils.uploadToStorage();
+
+        var upload = Upload.builder()
+            .id(DownloadUploadTest.class.getSimpleName())
+            .type(DownloadUploadTest.class.getName())
+            .from(Property.ofValue(uri.toString()))
+            .to(Property.ofValue(IdUtils.create() + "/" + IdUtils.create() + ".yaml"))
+            .host(Property.ofValue("127.0.0.1"))
+            .port(Property.ofValue("6990"))
+            .username(USERNAME)
+            .password(PASSWORD)
+            .insecureTrustAllCertificates(Property.ofValue(true))
+            .build();
+
+        upload.run(TestsUtils.mockRunContext(runContextFactory, upload, Map.of()));
+
+        String expectedLog = "insecureTrustAllCertificates";
+        TestsUtils.awaitLog(logs, log -> log.getMessage() != null && log.getMessage().contains(expectedLog));
+        receive.blockLast();
+        assertThat(logs.stream().anyMatch(log -> log.getMessage() != null && log.getMessage().contains(expectedLog)), is(true));
     }
 
     private static void waitForPort(String host, int port, Duration timeout) throws Exception {

--- a/src/test/java/io/kestra/plugin/fs/smb/AbstractSmbTaskTest.java
+++ b/src/test/java/io/kestra/plugin/fs/smb/AbstractSmbTaskTest.java
@@ -1,0 +1,39 @@
+package io.kestra.plugin.fs.smb;
+
+import io.kestra.core.models.property.Property;
+import io.kestra.core.utils.IdUtils;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+class AbstractSmbTaskTest {
+
+    @Test
+    void toStringShouldNotLeakCredentials() {
+        String secretPassword = "S3cr3t-P@ssw0rd!";
+
+        TestTask task = TestTask.builder()
+            .id(IdUtils.create())
+            .type(TestTask.class.getName())
+            .host(Property.ofValue("localhost"))
+            .username(Property.ofValue("admin"))
+            .password(Property.ofValue(secretPassword))
+            .build();
+
+        String toString = task.toString();
+
+        assertThat(toString, not(containsString(secretPassword)));
+        assertThat(toString, not(containsString("admin")));
+    }
+
+    // Deliberately declares no @ToString: it must inherit AbstractSmbTask's own generated
+    // toString() so this test actually exercises the credential-masking fix.
+    @SuperBuilder
+    @NoArgsConstructor
+    public static class TestTask extends AbstractSmbTask {
+    }
+}

--- a/src/test/java/io/kestra/plugin/fs/smb/DownloadChecksumTest.java
+++ b/src/test/java/io/kestra/plugin/fs/smb/DownloadChecksumTest.java
@@ -2,19 +2,25 @@ package io.kestra.plugin.fs.smb;
 
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.fs.vfs.ChecksumService;
 import io.kestra.plugin.fs.vfs.Download.Output;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static io.kestra.plugin.fs.smb.SmbUtils.PASSWORD;
 import static io.kestra.plugin.fs.smb.SmbUtils.USERNAME;
@@ -31,6 +37,10 @@ class DownloadChecksumTest {
 
     @Inject
     private SmbUtils smbUtils;
+
+    @Inject
+    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
+    private QueueInterface<LogEntry> logQueue;
 
     private static final String CONTENT = "deterministic content for checksum tests";
 
@@ -120,6 +130,9 @@ class DownloadChecksumTest {
 
     @Test
     void downloadWithMd5Algorithm() throws Exception {
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        var receive = TestsUtils.receive(logQueue, l -> logs.add(l.getLeft()));
+
         String remotePath = uploadFixture();
 
         Download task = downloadBuilder(remotePath)
@@ -131,5 +144,9 @@ class DownloadChecksumTest {
         Output output = task.run(TestsUtils.mockRunContext(runContextFactory, task, Map.of()));
 
         assertThat(output.getChecksum(), is(md5(CONTENT)));
+
+        TestsUtils.awaitLog(logs, log -> log.getMessage() != null && log.getMessage().contains("deprecated"));
+        receive.blockLast();
+        assertThat(logs.stream().anyMatch(log -> log.getMessage() != null && log.getMessage().contains("MD5") && log.getMessage().contains("deprecated")), is(true));
     }
 }

--- a/src/test/java/io/kestra/plugin/fs/ssh/CommandTest.java
+++ b/src/test/java/io/kestra/plugin/fs/ssh/CommandTest.java
@@ -18,7 +18,10 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 // WARNING, the 'setpasswd.sh' script must be runnable for the test to pass, if the test fail try launching:
 // chmod go+x src/test/resources/ssh/setpasswd.sh
@@ -90,6 +93,103 @@ class CommandTest {
         )));
 
         assertThat(String.valueOf(exception.getMessage()).contains("UnknownHostException"), is(false));
+    }
+
+    @Test
+    void toString_shouldNotLeakSecrets() {
+        String password = "O7m)&H/0Em4/T8RqCa!Al=M@N6^;@+";
+        String privateKey = "-----BEGIN OPENSSH PRIVATE KEY-----\nfakeKeyMaterialForTestingPurposesOnly\n-----END OPENSSH PRIVATE KEY-----";
+        String privateKeyPassphrase = "s3cr3t-passphrase";
+
+        Command command = Command.builder()
+            .id(IdUtils.create())
+            .type(Command.class.getName())
+            .host(Property.ofValue("localhost"))
+            .username(USERNAME)
+            .authMethod(Property.ofValue(AuthMethod.PUBLIC_KEY))
+            .password(Property.ofValue(password))
+            .privateKey(Property.ofValue(privateKey))
+            .privateKeyPassphrase(Property.ofValue(privateKeyPassphrase))
+            .port(Property.ofValue("2222"))
+            .commands(new String[] {"echo 0"})
+            .build();
+
+        String toString = command.toString();
+
+        assertThat(toString, not(containsString(password)));
+        assertThat(toString, not(containsString(privateKey)));
+        assertThat(toString, not(containsString(privateKeyPassphrase)));
+    }
+
+    @Test
+    void run_proxyCommand_rejectsShellMetacharactersInHost() {
+        for (String maliciousHost : new String[] {"127.0.0.1; touch /tmp/pwned", "127.0.0.1 | id", "$(id)"}) {
+            Command command = Command.builder()
+                .id(IdUtils.create())
+                .type(Command.class.getName())
+                .host(Property.ofValue(maliciousHost))
+                .username(USERNAME)
+                .authMethod(Property.ofValue(AuthMethod.PASSWORD))
+                .password(PASSWORD)
+                .port(Property.ofValue("2222"))
+                .proxyCommand(Property.ofValue("echo %h"))
+                .commands(new String[] {"echo 0"})
+                .build();
+
+            IllegalArgumentException exception = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> command.run(TestsUtils.mockRunContext(runContextFactory, command, Map.of())),
+                "Expected rejection for host: " + maliciousHost
+            );
+
+            assertThat(exception.getMessage(), containsString("host"));
+        }
+    }
+
+    @Test
+    void run_proxyCommand_rejectsShellMetacharactersInUsername() {
+        Command command = Command.builder()
+            .id(IdUtils.create())
+            .type(Command.class.getName())
+            .host(Property.ofValue("127.0.0.1"))
+            .username(Property.ofValue("root; touch /tmp/pwned"))
+            .authMethod(Property.ofValue(AuthMethod.PASSWORD))
+            .password(PASSWORD)
+            .port(Property.ofValue("2222"))
+            .proxyCommand(Property.ofValue("echo %r"))
+            .commands(new String[] {"echo 0"})
+            .build();
+
+        IllegalArgumentException exception = Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> command.run(TestsUtils.mockRunContext(runContextFactory, command, Map.of()))
+        );
+
+        assertThat(exception.getMessage(), containsString("username"));
+    }
+
+    @Test
+    void run_proxyCommand_allowsLegitimateHostAndUsername() {
+        Command command = Command.builder()
+            .id(IdUtils.create())
+            .type(Command.class.getName())
+            .host(Property.ofValue("my-host.example.com"))
+            .username(Property.ofValue("svc_user@example.com"))
+            .authMethod(Property.ofValue(AuthMethod.PASSWORD))
+            .password(PASSWORD)
+            .port(Property.ofValue("2222"))
+            .proxyCommand(Property.ofValue("echo %h %r"))
+            .commands(new String[] {"echo 0"})
+            .build();
+
+        // A legitimate host/username must pass sanitization and reach the (fake) proxy shell command;
+        // the subsequent SSH handshake still fails since `echo` doesn't speak SSH, but never with IllegalArgumentException.
+        Exception exception = Assertions.assertThrows(
+            Exception.class,
+            () -> command.run(TestsUtils.mockRunContext(runContextFactory, command, Map.of()))
+        );
+
+        assertThat(exception, is(not(instanceOf(IllegalArgumentException.class))));
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/fs/vfs/AbstractVfsTaskTest.java
+++ b/src/test/java/io/kestra/plugin/fs/vfs/AbstractVfsTaskTest.java
@@ -1,0 +1,59 @@
+package io.kestra.plugin.fs.vfs;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.IdUtils;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+class AbstractVfsTaskTest {
+
+    @Test
+    void toStringShouldNotLeakCredentials() {
+        String secretPassword = "S3cr3t-P@ssw0rd!";
+
+        TestTask task = TestTask.builder()
+            .id(IdUtils.create())
+            .type(TestTask.class.getName())
+            .host(Property.ofValue("localhost"))
+            .username(Property.ofValue("admin"))
+            .password(Property.ofValue(secretPassword))
+            .build();
+
+        String toString = task.toString();
+
+        assertThat(toString, not(containsString(secretPassword)));
+        assertThat(toString, not(containsString("admin")));
+    }
+
+    // Deliberately declares no @ToString: it must inherit AbstractVfsTask's own generated
+    // toString() so this test actually exercises the credential-masking fix.
+    @SuperBuilder
+    @Getter
+    @NoArgsConstructor
+    public static class TestTask extends AbstractVfsTask {
+        @Builder.Default
+        private Property<String> port = Property.ofValue("22");
+
+        @Override
+        protected FileSystemOptions fsOptions(RunContext runContext) throws IllegalVariableEvaluationException, IOException {
+            return new FileSystemOptions();
+        }
+
+        @Override
+        protected String scheme() {
+            return "test";
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes all 7 findings from the security audit EPIC #332.

- **HIGH-001** (closes #333): `@ToString.Exclude` on `password`/`username` in `AbstractVfsTask`, `AbstractSmbTask`, plus module-wide sweep — `vfs/Trigger`, `smb/Trigger`, and all 8 SFTP task classes (`keyfile`, `passphrase`, `proxyUsername`, `proxyPassword`).
- **HIGH-002** (closes #334): `@ToString.Exclude` on `password`, `privateKey`, `privateKeyPassphrase` in `ssh/Command`.
- **HIGH-003** (closes #335): allowlist-sanitize `host`/`username` before substitution into the SSH `ProxyCommand` shell invocation — blocks shell injection/RCE via `%h`/`%r`.
- **MEDIUM-001**: runtime `logger.warn()` when `insecureTrustAllCertificates` disables FTPS cert validation; schema description now discourages production use.
- **MEDIUM-002**: replaced `System.out`/`System.err` with `runContext.logger()` in TCP/UDP `RealtimeTrigger` so output stays subject to secret redaction.
- **LOW-001**: deprecated MD5/SHA-1 in `ChecksumService`, warn at runtime when selected.
- **LOW-002**: `AbstractVfsTask.password` now annotated `@PluginProperty(secret = true)`.

Closes #333, Closes #334, Closes #335. Part of #332.

## Test plan

- [x] `./gradlew build` green
- [x] `./gradlew test` — 178/178 passing
- [x] New tests cover: toString() secret exclusion (vfs/smb/ssh), proxy-command injection rejection + legit host/username still works, FTPS insecure-trust warning log, MD5 checksum deprecation warning