### PR TITLE
fix(sanity-checks): avoid brotli content-encoding in request sanity flow

### DIFF
--- a/src/test/resources/sanity-checks/request.yaml
+++ b/src/test/resources/sanity-checks/request.yaml
@@ -5,6 +5,8 @@ tasks:
   - id: request
     type: io.kestra.plugin.core.http.Request
     uri: https://dummyjson.com/products
+    headers:
+      Accept-Encoding: gzip
 
   - id: assert
     type: io.kestra.plugin.core.execution.Assert


### PR DESCRIPTION
## Summary
- Sanity check `request` flow fails: `io.kestra.plugin.core.http.Request` hits dummyjson.com (behind Cloudflare), gets back `Content-Encoding: br`, and httpclient5's brotli decoder throws `UnsatisfiedLinkError` (`brotli4j` Java bindings resolve on the classpath but no matching native artifact does).
- Root cause is in kestra-core's httpclient5/brotli4j dependency setup, not plugin-fs code — out of scope to fix here (real fix: kestra-io/kestra#17275).
- Workaround: force `Accept-Encoding: gzip` on the request task so the server never picks brotli.

## Test plan
- [x] Sanity check flow no longer triggers brotli decoding path
- [x] Confirmed flow passes end-to-end